### PR TITLE
resets the react native event handlers so they are not continually added

### DIFF
--- a/ReactNative/Native/ReactNative.js
+++ b/ReactNative/Native/ReactNative.js
@@ -1,6 +1,5 @@
 Elm.Native.ReactNative = {};
 Elm.Native.ReactNative.make = function(localRuntime) {
-
     localRuntime.Native = localRuntime.Native || {};
     localRuntime.Native.ReactNative = localRuntime.Native.ReactNative || {};
     if (localRuntime.Native.ReactNative.values) {
@@ -10,10 +9,16 @@ Elm.Native.ReactNative.make = function(localRuntime) {
     var Json = Elm.Native.Json.make(localRuntime);
     var Signal = Elm.Native.Signal.make(localRuntime);
 
+    var prepareReset = true;
     var eventHandlerCount = 0;
     localRuntime.ports._ReactNativeEventHandlers = {};
 
     function on(decoder, createMessage) {
+        if(prepareReset){
+            eventHandlerCount = 0;
+            localRuntime.ports._ReactNativeEventHandlers = {};
+        }
+
         function eventHandler(event) {
             var value = A2(Json.runDecoderValue, decoder, event);
             if (value.ctor === 'Ok') {
@@ -21,7 +26,12 @@ Elm.Native.ReactNative.make = function(localRuntime) {
             }
         }
         localRuntime.ports._ReactNativeEventHandlers[++eventHandlerCount] = eventHandler;
+        prepareReset = false;
         return eventHandlerCount;
+    }
+
+    Elm.Native.ReactNative.prepareResetHandlers = function () {
+        var prepareReset = true;
     }
 
     localRuntime.Native.ReactNative.values = {

--- a/ReactNative/Native/ReactNative.js
+++ b/ReactNative/Native/ReactNative.js
@@ -31,7 +31,7 @@ Elm.Native.ReactNative.make = function(localRuntime) {
     }
 
     Elm.Native.ReactNative.prepareResetHandlers = function () {
-        var prepareReset = true;
+        prepareReset = true;
     }
 
     localRuntime.Native.ReactNative.values = {

--- a/elm.js
+++ b/elm.js
@@ -8287,7 +8287,6 @@ Elm.Json.Decode.make = function (_elm) {
 };
 Elm.Native.ReactNative = {};
 Elm.Native.ReactNative.make = function(localRuntime) {
-
     localRuntime.Native = localRuntime.Native || {};
     localRuntime.Native.ReactNative = localRuntime.Native.ReactNative || {};
     if (localRuntime.Native.ReactNative.values) {
@@ -8297,10 +8296,16 @@ Elm.Native.ReactNative.make = function(localRuntime) {
     var Json = Elm.Native.Json.make(localRuntime);
     var Signal = Elm.Native.Signal.make(localRuntime);
 
+    var prepareReset = true;
     var eventHandlerCount = 0;
     localRuntime.ports._ReactNativeEventHandlers = {};
 
     function on(decoder, createMessage) {
+        if(prepareReset){
+            eventHandlerCount = 0;
+            localRuntime.ports._ReactNativeEventHandlers = {};
+        }
+
         function eventHandler(event) {
             var value = A2(Json.runDecoderValue, decoder, event);
             if (value.ctor === 'Ok') {
@@ -8308,7 +8313,12 @@ Elm.Native.ReactNative.make = function(localRuntime) {
             }
         }
         localRuntime.ports._ReactNativeEventHandlers[++eventHandlerCount] = eventHandler;
+        prepareReset = false;
         return eventHandlerCount;
+    }
+
+    Elm.Native.ReactNative.prepareResetHandlers = function () {
+        var prepareReset = true;
     }
 
     localRuntime.Native.ReactNative.values = {

--- a/index.android.js
+++ b/index.android.js
@@ -29,7 +29,8 @@ function componentFactory() {
   return React.createClass({
     componentWillMount() {
       program.ports.vtreeOutput.subscribe(vtree => {
-        this.setState({vtree})
+        this.setState({vtree});
+        Elm.Native.ReactNative.prepareResetHandlers();
       });
       program.ports.init.send([]);
     },

--- a/index.ios.js
+++ b/index.ios.js
@@ -33,7 +33,8 @@ function componentFactory() {
   return React.createClass({
     componentWillMount() {
       program.ports.vtreeOutput.subscribe(vtree => {
-        this.setState({vtree})
+        this.setState({vtree});
+        Elm.Native.ReactNative.prepareResetHandlers();
       });
       program.ports.init.send([]);
     },


### PR DESCRIPTION
Resets localRuntime.ports._ReactNativeEventHandlers so it doesn't continually create more handlers.

I did it because when adding a timer to a project, the vtree continuously gets created so the number of handlers gets out of hand.

Thanks
