### PR TITLE
Return VTree from main

### DIFF
--- a/ElmAppWrapper.js
+++ b/ElmAppWrapper.js
@@ -1,0 +1,41 @@
+'use strict';
+var React = require('react-native');
+var Elm = require('./elm');
+var {
+  AppRegistry,
+  StyleSheet,
+  Text,
+  View,
+  Image,
+} = React;
+
+
+function componentFactory() {
+  return React.createClass({
+    componentWillMount() {
+      Elm.embedReact(Elm.Main, this);
+    },
+    getInitialState() {
+      return {
+        _elmVTree: React.createElement(View, {}, []),
+      };
+    },
+    render() {
+      var vtree = this.state._elmVTree;
+      console.log('react app rendering vtree: ', vtree);
+      return React.createElement(View, {style: styles.container},
+        vtree
+      );
+    },
+  })
+}
+
+var styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+});
+
+module.exports = componentFactory;

--- a/Main.elm
+++ b/Main.elm
@@ -8,11 +8,15 @@ import ReactNative.NativeApp as NativeApp
 import ReactNative.Style as Style exposing ( defaultTransform )
 
 
--- "main"
-port viewTree : Signal Json.Encode.Value
-port viewTree =
+app =
   NativeApp.start { model = model, view = view, update = update, init = init }
 
+main = 
+  app.html
+
+port tasks : Signal (Task.Task Never ())
+port tasks =
+  app.tasks
 
 type alias Model = Int
 
@@ -77,7 +81,3 @@ button address action color content =
     ]
     (Just <| RN.onPress address action)
     content
-
-
--- for the first vtree
-port init : Signal ()

--- a/Main.elm
+++ b/Main.elm
@@ -9,14 +9,14 @@ import ReactNative.Style as Style exposing ( defaultTransform )
 
 
 app =
-  NativeApp.start { model = model, view = view, update = update, init = init }
+  NativeApp.start { model = model, view = view, update = update }
 
-main = 
-  app.html
+main =
+  app
 
-port tasks : Signal (Task.Task Never ())
-port tasks =
-  app.tasks
+-- port tasks : Signal (Task.Task Never ())
+-- port tasks =
+--   app.tasks
 
 type alias Model = Int
 

--- a/Main.elm
+++ b/Main.elm
@@ -28,24 +28,33 @@ model = 9000
 view : Signal.Address Action -> Model -> RN.VTree
 view address count =
   RN.view
-    [ Style.alignItems "center"
+    [ RN.style [ Style.alignItems "center" ]
     ]
     [ RN.image
-      [ Style.height 64
-      , Style.width 64
-      , Style.marginBottom 30
+      [ RN.style
+        [ Style.height 64
+        , Style.width 64
+        , Style.marginBottom 30
+        ]
+      , RN.imageSource "https://raw.githubusercontent.com/futurice/spiceprogram/master/assets/img/logo/chilicorn_no_text-128.png"
       ]
-      "https://raw.githubusercontent.com/futurice/spiceprogram/master/assets/img/logo/chilicorn_no_text-128.png"
+      [
+      ]
+
     , RN.text
-      [ Style.textAlign "center"
-      , Style.marginBottom 30
+      [ RN.style
+        [ Style.textAlign "center"
+        , Style.marginBottom 30
+        ]
       ]
-      Nothing
-      ("Counter: " ++ toString count)
+      [ RN.string ("Counter: " ++ toString count)
+      ]
     , RN.view
-      [ Style.width 80
-      , Style.flexDirection "row"
-      , Style.justifyContent "space-between"
+      [ RN.style
+        [ Style.width 80
+        , Style.flexDirection "row"
+        , Style.justifyContent "space-between"
+        ]
       ]
       [ button address Decrement "#d33" "-"
       , button address Increment "#3d3" "+"
@@ -66,18 +75,20 @@ update action model =
 button : Signal.Address Action -> Action -> String -> String -> RN.VTree
 button address action color content =
   RN.text
-    [ Style.color "white"
-    , Style.textAlign "center"
-    , Style.backgroundColor color
-    , Style.paddingTop 5
-    , Style.paddingBottom 5
-    , Style.width 30
-    , Style.fontWeight "bold"
-    , Style.shadowColor "#000"
-    , Style.shadowOpacity 0.25
-    , Style.shadowOffset 1 1
-    , Style.shadowRadius 5
-    , Style.transform { defaultTransform | rotate = Just "10deg" }
+    [ RN.style
+      [ Style.color "white"
+      , Style.textAlign "center"
+      , Style.backgroundColor color
+      , Style.paddingTop 5
+      , Style.paddingBottom 5
+      , Style.width 30
+      , Style.fontWeight "bold"
+      , Style.shadowColor "#000"
+      , Style.shadowOpacity 0.25
+      , Style.shadowOffset 1 1
+      , Style.shadowRadius 5
+      , Style.transform { defaultTransform | rotate = Just "10deg" }
+      ]
+    , RN.onPress address action
     ]
-    (Just <| RN.onPress address action)
-    content
+    [ RN.string content ]

--- a/README.md
+++ b/README.md
@@ -13,6 +13,24 @@ No.
 
 ## Get it running
 
+
+### Caution: Experimental software!
+
+The newest version of Elm Native UI depends on
+
+- [modified Elm compiler](https://github.com/NoRedInk/elm-compiler/tree/elm-native-ui) ([ZIP](https://github.com/NoRedInk/elm-compiler/archive/elm-native-ui.zip)) &mdash; Must be on your `PATH` before the standard elm-compiler. You will need to [build the compiler from source](https://github.com/NoRedInk/elm-compiler/tree/elm-native-ui#build-from-source--contribute) yourself for now.
+
+- [modified elm-core](https://github.com/yusefnapora/core/tree/elm-native-ui) ([ZIP](https://github.com/yusefnapora/core/archive/elm-native-ui.zip)) &mdash; Must replace the `elm-stuff/packages/elm-lang/core/3.0.0` directory in your project.
+
+The modified compiler will allow our React Native "Virtual Tree", or `VTree` for short, to pass through `main`, just like `Html` from elm-html does.
+
+The modified elm-core adds a function to enable rendering for the VTree type.
+
+_If you clone the repositories yourself, make sure you checkout the elm-native-ui branch on each of them before using._
+
+
+### Actually getting it running
+
 Install React Native following [their guide](https://facebook.github.io/react-native/docs/getting-started.html#content). Check that you can create a new project with `react-native init AwesomeProject` and try running it on a real or virtual device.
 
 Once that's out of the way, clone this repository and in the directory:

--- a/ReactNative/Native/ReactNative.js
+++ b/ReactNative/Native/ReactNative.js
@@ -6,9 +6,10 @@ Elm.Native.ReactNative.make = function(localRuntime) {
         return localRuntime.Native.ReactNative.values;
     }
 
+    var List = Elm.Native.List.make(localRuntime);
     var Json = Elm.Native.Json.make(localRuntime);
     var Signal = Elm.Native.Signal.make(localRuntime);
-
+    var React = require('react-native');
 
     function nativeEventHandler(decoder, createMessage) {
         function eventHandler(event) {
@@ -20,7 +21,75 @@ Elm.Native.ReactNative.make = function(localRuntime) {
         return eventHandler;
     }
 
+    function vtreeToReactElement(vtree) {
+      switch (vtree.ctor) {
+        case 'VString':
+          return vtree._0;
+        case 'VNode': {
+          let tagName = vtree._0;
+          let propertyList = vtree._1;
+          let childNodes = vtree._2;
+
+          let reactClass = React[tagName];
+          let props = propertyListToJS(propertyList);
+          let children = List.toArray(childNodes).map(vtreeToReactElement);
+
+          return React.createElement(reactClass, props, ...children);
+        }
+      }
+    }
+
+    function propertyToJS(property) {
+      console.log('converting RN property: ', property);
+
+      if (property.ctor !== 'JsonProperty' &&
+          property.ctor !== 'NativeProperty') {
+        return undefined;
+      }
+
+      return {
+        key: property._0,
+        value: property._1,
+      }
+    }
+
+    function propertyListToJS(list)
+  	{
+  		var object = {};
+  		while (list.ctor !== '[]')
+  		{
+  			var entry = propertyToJS(list._0);
+        if (entry) {
+  			  object[entry.key] = entry.value;
+        }
+  			list = list._1;
+  		}
+  		return object;
+  	}
+
+    function render(vtree) {
+      return vtreeToReactElement(vtree);
+    }
+
+    function setReactVTree(reactElement, vtree) {
+      console.info('updating vtree: ', vtree);
+
+			var newState = Object.assign({},
+				reactElement.state,
+				{_elmVTree: vtreeToReactElement(vtree)}
+			);
+
+			reactElement.setState(newState);
+		}
+
+    function updateAndReplace(containerElement, oldVTree, newVTree) {
+      setReactVTree(containerElement, newVTree);
+    }
+
+
     localRuntime.Native.ReactNative.values = {
+        render: render,
+        updateAndReplace: updateAndReplace,
         nativeEventHandler: F2(nativeEventHandler),
     };
     return localRuntime.Native.ReactNative.values;

--- a/ReactNative/Native/ReactNative.js
+++ b/ReactNative/Native/ReactNative.js
@@ -52,7 +52,7 @@ Elm.Native.ReactNative.make = function(localRuntime) {
           property.ctor !== 'NativeProperty') {
         throw new Error("I don't know how to handle a Property of type '" + property.ctor + "'\n" +
           "If you've recently added a new type of Property, you must edit the\n" +
-          "function Native.ReactiNative.propertyToObject");
+          "function Native.ReactNative.propertyToObject");
       }
 
       return {

--- a/ReactNative/Native/ReactNative.js
+++ b/ReactNative/Native/ReactNative.js
@@ -24,8 +24,11 @@ Elm.Native.ReactNative.make = function(localRuntime) {
     function vtreeToReactElement(vtree) {
       switch (vtree.ctor) {
         case 'VString':
+        {
           return vtree._0;
-        case 'VNode': {
+        }
+        case 'VNode':
+        {
           let tagName = vtree._0;
           let propertyList = vtree._1;
           let childNodes = vtree._2;
@@ -36,6 +39,10 @@ Elm.Native.ReactNative.make = function(localRuntime) {
 
           return React.createElement(reactClass, props, ...children);
         }
+        default:
+          throw new Error(`I don't know how to render a VTree of type '${vtree.ctor}'.\n` +
+            `If you've recently added a new type of VTree, you must add a new case to\n` +
+            `the switch statement in Native.ReactNative.vtreeToReactElement()`);
       }
     }
 

--- a/ReactNative/Native/ReactNative.js
+++ b/ReactNative/Native/ReactNative.js
@@ -40,8 +40,6 @@ Elm.Native.ReactNative.make = function(localRuntime) {
     }
 
     function propertyToJS(property) {
-      console.log('converting RN property: ', property);
-
       if (property.ctor !== 'JsonProperty' &&
           property.ctor !== 'NativeProperty') {
         return undefined;
@@ -72,8 +70,6 @@ Elm.Native.ReactNative.make = function(localRuntime) {
     }
 
     function setReactVTree(reactElement, vtree) {
-      console.info('updating vtree: ', vtree);
-
 			var newState = Object.assign({},
 				reactElement.state,
 				{_elmVTree: vtreeToReactElement(vtree)}

--- a/ReactNative/Native/ReactNative.js
+++ b/ReactNative/Native/ReactNative.js
@@ -9,33 +9,19 @@ Elm.Native.ReactNative.make = function(localRuntime) {
     var Json = Elm.Native.Json.make(localRuntime);
     var Signal = Elm.Native.Signal.make(localRuntime);
 
-    var prepareReset = true;
-    var eventHandlerCount = 0;
-    localRuntime.ports._ReactNativeEventHandlers = {};
 
-    function on(decoder, createMessage) {
-        if(prepareReset){
-            eventHandlerCount = 0;
-            localRuntime.ports._ReactNativeEventHandlers = {};
-        }
-
+    function nativeEventHandler(decoder, createMessage) {
         function eventHandler(event) {
             var value = A2(Json.runDecoderValue, decoder, event);
             if (value.ctor === 'Ok') {
                 Signal.sendMessage(createMessage(value._0));
             }
         }
-        localRuntime.ports._ReactNativeEventHandlers[++eventHandlerCount] = eventHandler;
-        prepareReset = false;
-        return eventHandlerCount;
-    }
-
-    Elm.Native.ReactNative.prepareResetHandlers = function () {
-        prepareReset = true;
+        return eventHandler;
     }
 
     localRuntime.Native.ReactNative.values = {
-        on: F2(on),
+        nativeEventHandler: F2(nativeEventHandler),
     };
     return localRuntime.Native.ReactNative.values;
 };

--- a/ReactNative/Native/ReactNative.js
+++ b/ReactNative/Native/ReactNative.js
@@ -29,44 +29,45 @@ Elm.Native.ReactNative.make = function(localRuntime) {
         }
         case 'VNode':
         {
-          let tagName = vtree._0;
-          let propertyList = vtree._1;
-          let childNodes = vtree._2;
+          var tagName = vtree._0;
+          var propertyList = vtree._1;
+          var childNodes = vtree._2;
 
-          let reactClass = React[tagName];
-          let props = propertyListToJS(propertyList);
-          let children = List.toArray(childNodes).map(vtreeToReactElement);
+          var reactClass = React[tagName];
+          var props = propertyListToObject(propertyList);
+          var children = List.toArray(childNodes).map(vtreeToReactElement);
 
-          return React.createElement(reactClass, props, ...children);
+          var args = [reactClass, props].concat(children);
+          return React.createElement.apply(null, args);
         }
         default:
-          throw new Error(`I don't know how to render a VTree of type '${vtree.ctor}'.\n` +
-            `If you've recently added a new type of VTree, you must add a new case to\n` +
-            `the switch statement in Native.ReactNative.vtreeToReactElement()`);
+          throw new Error("I don't know how to render a VTree of type '" + vtree.ctor + "'\n" +
+            "If you've recently added a new type of VTree, you must add a new case to\n" +
+            "the switch statement in Native.ReactNative.vtreeToReactElement");
       }
     }
 
-    function propertyToJS(property) {
+    function propertyToObject(property) {
       if (property.ctor !== 'JsonProperty' &&
           property.ctor !== 'NativeProperty') {
-        return undefined;
+        throw new Error("I don't know how to handle a Property of type '" + property.ctor + "'\n" +
+          "If you've recently added a new type of Property, you must edit the\n" +
+          "function Native.ReactiNative.propertyToObject");
       }
 
       return {
         key: property._0,
         value: property._1,
-      }
+      };
     }
 
-    function propertyListToJS(list)
+    function propertyListToObject(list)
   	{
   		var object = {};
   		while (list.ctor !== '[]')
   		{
-  			var entry = propertyToJS(list._0);
-        if (entry) {
-  			  object[entry.key] = entry.value;
-        }
+  			var entry = propertyToObject(list._0);
+  			object[entry.key] = entry.value;
   			list = list._1;
   		}
   		return object;

--- a/ReactNative/NativeApp.elm
+++ b/ReactNative/NativeApp.elm
@@ -10,11 +10,10 @@ type alias Config model action =
   { model : model
   , view : Signal.Address action -> model -> RN.VTree
   , update : action -> model -> model
-  , init : Signal ()
   }
 
 
-start : Config model action -> Signal Json.Encode.Value
+start : Config model action -> Signal RN.VTree
 start config =
   let
     actions =
@@ -23,7 +22,6 @@ start config =
     merged =
       Signal.mergeMany
         [ Signal.map ConfigAction actions.signal
-        , Signal.map (always Init) config.init
         ]
 
     address =
@@ -50,4 +48,3 @@ start config =
   in
     model
     |> Signal.map (config.view address)
-    |> Signal.map RN.encode

--- a/ReactNative/ReactNative.elm
+++ b/ReactNative/ReactNative.elm
@@ -13,58 +13,146 @@ import ReactNative.Style as RnStyle
 import Native.ElmFunctions
 import Native.ReactNative
 
-
+{-| A node in the virtual View Tree that forms the basis of the UI for your app.
+-}
 type VTree
   = VNode String (List Property) (List VTree)
   | VString String
 
 
+{-| `VTree` nodes take a List of Properties (or "props") to specify their behavior and presentation.
+Most Properties can be represented as Json values, and you should always try to do so if possible.
+If you must use a property that can't be encoded as Json, the NativeProperty tag can be used
+to attach an opaque `NativeValue`.
+-}
 type Property
   = JsonProperty String Json.Decode.Value
   | NativeProperty String NativeValue
 
 
+{-| An opaque value that is backed by a Native javascript value.
+This is used to attach event handlers to `VTree` nodes, since functions can't be encoded
+as Json values.
+
+Try not to use `NativeValue` if you can avoid it, since the compiler can't help you
+catch any mistakes that might lead to runtime errors.
+-}
 type NativeValue = NativeValue
 
 
+{-| Create a `VTree` node with the given `tagName`, a list of properties,
+and a list of child `VTree` nodes.
+
+The `tagName` will be used to look up a React Component class with the same name,
+so e.g. `node "View"` will render a React Native `View` component.
+-}
 node : String -> List Property -> List VTree -> VTree
 node tagName props children =
   VNode tagName props children
 
 
+{-| Just turn a plain text string into a `VTree` node, so that you can add it
+as a child of another node.
+
+    text
+      [ style
+        [ Style.fontSize 20
+        , Style.color "blue"
+        ]
+      ]
+      [ string "Hello World!" ]
+-}
 string : String -> VTree
 string =
   VString
 
 
+{-| Create a React Native `View` element with the given properties and children.
+
+`View` is the fundamental building block of React Native's UI component system.
+It represents a rectangle on the screen, and is commonly used as a container for
+other UI elements, similar to a `div` in HTML.
+-}
 view : List Property -> List VTree -> VTree
 view =
   VNode "View"
 
 
+{-| Create a React Native `Text` element.
+
+`Text` elements let you add styles, event handlers, and other React Native properties to
+text strings.  They can be nested, for example, if you want part of a string to be bold:
+
+    text
+      [ onPress address SayHello ]
+      [ string "This text has default styling, but "
+      , text
+          [ style [ Style.fontWeight "bold" ] ]
+          [ string "this is BOLD!" ]
+      ]
+
+Since the `onPress` handler is attached to the outer `text` element, you can press on
+either the bold or unstyled text to `SayHello`.
+-}
 text : List Property -> List VTree -> VTree
 text =
   VNode "Text"
 
+{-| Create a React Native `Image` element.
 
+Use these for displaying images from the web, or (soon!) images that are bundled
+in with your app.
+
+To tell the image element what to render, you need to give it an `imageSource` property
+with the URI of the image.
+
+Unlike the HTML `image` tag, a React Native `Image` element will not resize to fit its contents,
+so you must provide some way for the layout engine to determine the size,
+or else it won't show up onscreen.  You can either set an explicit `width` and `height` in the
+`style` property, or you can use flexbox to have the image size itself proportionally to its
+container.
+
+An image element can have children, in which case it acts similarly to the `background-image`
+CSS property on the web:
+
+    image
+      [ imageSource "http://example.com/fuzzy_kitten.png"
+      , style
+        [ Style.width 100
+        , Style.height 100
+        , Style.alignItems "center"
+        ]
+      ]
+      [ text
+          [ style [ Style.fontSize 30 ] ]
+          [ string "This text will be rendered inside the image.  It's meme time!" ]
+      ]
+-}
 image : List Property -> List VTree -> VTree
-image props source =
-  VNode "Image" props source
+image =
+  VNode "Image"
 
 
 -- Properties
 
+{-| Attach arbitrary properties to `VTree` nodes.
 
+Use this for properties that can be represented as Json values.
+-}
 property : String -> Json.Decode.Value -> Property
-property =
-  JsonProperty
+property name value =
+  JsonProperty name value
 
-
+{-| Turns a String URI into the "source" property for an image element.
+-}
 imageSource : String -> Property
 imageSource uri =
   Json.Encode.object [ ("uri", Json.Encode.string uri) ]
     |> property "source"
 
+
+{-| Turns a list of `Style`s into a property you can attach to a `VTree` node.
+-}
 style : List RnStyle.Style -> Property
 style styles =
   RnStyle.encode styles

--- a/elm-package.json
+++ b/elm-package.json
@@ -1,7 +1,7 @@
 {
     "version": "1.0.0",
     "summary": "Experimental support for writing React Native powered mobile applications",
-    "repository": "https://github.com/ohanhi/elm-native.git",
+    "repository": "https://github.com/elm-native-ui/elm-native-ui.git",
     "license": "BSD3",
     "source-directories": [
         ".",

--- a/elm.js
+++ b/elm.js
@@ -8869,7 +8869,7 @@ Elm.Native.ReactNative.make = function(localRuntime) {
         default:
           throw new Error("I don't know how to render a VTree of type '" + vtree.ctor + "'\n" +
             "If you've recently added a new type of VTree, you must add a new case to\n" +
-            "the switch statement in Native.ReactNative.vtreeToReactElement()");
+            "the switch statement in Native.ReactNative.vtreeToReactElement");
       }
     }
 
@@ -8878,7 +8878,7 @@ Elm.Native.ReactNative.make = function(localRuntime) {
           property.ctor !== 'NativeProperty') {
         throw new Error("I don't know how to handle a Property of type '" + property.ctor + "'\n" +
           "If you've recently added a new type of Property, you must edit the\n" +
-          "propertyToObject() function in Native.ReactiNative.js");
+          "function Native.ReactiNative.propertyToObject");
       }
 
       return {
@@ -8928,98 +8928,134 @@ Elm.Native.ReactNative.make = function(localRuntime) {
 Elm.ReactNative = Elm.ReactNative || {};
 Elm.ReactNative.ReactNative = Elm.ReactNative.ReactNative || {};
 Elm.ReactNative.ReactNative.make = function (_elm) {
-   "use strict";
-   _elm.ReactNative = _elm.ReactNative || {};
-   _elm.ReactNative.ReactNative = _elm.ReactNative.ReactNative || {};
-   if (_elm.ReactNative.ReactNative.values) return _elm.ReactNative.ReactNative.values;
-   var _U = Elm.Native.Utils.make(_elm),
-   $Basics = Elm.Basics.make(_elm),
-   $Debug = Elm.Debug.make(_elm),
-   $Json$Decode = Elm.Json.Decode.make(_elm),
-   $Json$Encode = Elm.Json.Encode.make(_elm),
-   $List = Elm.List.make(_elm),
-   $Maybe = Elm.Maybe.make(_elm),
-   $Native$ReactNative = Elm.Native.ReactNative.make(_elm),
-   $ReactNative$Style = Elm.ReactNative.Style.make(_elm),
-   $Result = Elm.Result.make(_elm),
-   $Signal = Elm.Signal.make(_elm);
-   var _op = {};
-   var nativeEventHandler = $Native$ReactNative.nativeEventHandler;
-   var NativeValue = {ctor: "NativeValue"};
-   var NativeProperty = F2(function (a,b) {    return {ctor: "NativeProperty",_0: a,_1: b};});
-   var on = F3(function (name,decoder,toMessage) {
-      var handler = A2(nativeEventHandler,decoder,toMessage);
-      var fullName = A2($Basics._op["++"],"on",name);
-      return A2(NativeProperty,fullName,handler);
-   });
-   var onPress = F2(function (address,msg) {    return A3(on,"Press",$Json$Decode.value,function (_p0) {    return A2($Signal.message,address,msg);});});
-   var JsonProperty = F2(function (a,b) {    return {ctor: "JsonProperty",_0: a,_1: b};});
-   var property = JsonProperty;
-   var imageSource = function (uri) {
-      return A2(property,"source",$Json$Encode.object(_U.list([{ctor: "_Tuple2",_0: "uri",_1: $Json$Encode.string(uri)}])));
-   };
-   var style = function (styles) {    return A2(property,"style",$ReactNative$Style.encode(styles));};
-   var VString = function (a) {    return {ctor: "VString",_0: a};};
-   var string = VString;
-   var VNode = F3(function (a,b,c) {    return {ctor: "VNode",_0: a,_1: b,_2: c};});
-   var node = F3(function (tagName,props,children) {    return A3(VNode,tagName,props,children);});
-   var view = VNode("View");
-   var text = VNode("Text");
-   var image = F2(function (props,source) {    return A3(VNode,"Image",props,source);});
-   return _elm.ReactNative.ReactNative.values = {_op: _op
-                                                ,node: node
-                                                ,string: string
-                                                ,view: view
-                                                ,text: text
-                                                ,image: image
-                                                ,style: style
-                                                ,imageSource: imageSource
-                                                ,onPress: onPress};
-};
+       "use strict";
+       _elm.ReactNative = _elm.ReactNative || {};
+       _elm.ReactNative.ReactNative = _elm.ReactNative.ReactNative ||
+           {};
+       if (_elm.ReactNative.ReactNative.values)
+          return _elm.ReactNative.ReactNative.values;
+       var _U = Elm.Native.Utils.make(_elm),
+       $Basics = Elm.Basics.make(_elm),
+       $Debug = Elm.Debug.make(_elm),
+       $Json$Decode = Elm.Json.Decode.make(_elm),
+       $Json$Encode = Elm.Json.Encode.make(_elm),
+       $List = Elm.List.make(_elm),
+       $Maybe = Elm.Maybe.make(_elm),
+       $Native$ReactNative = Elm.Native.ReactNative.make(_elm),
+       $ReactNative$Style = Elm.ReactNative.Style.make(_elm),
+       $Result = Elm.Result.make(_elm),
+       $Signal = Elm.Signal.make(_elm);
+       var _op = {};
+       var nativeEventHandler = $Native$ReactNative.nativeEventHandler;
+       var NativeValue = {ctor: "NativeValue"};
+       var NativeProperty = F2(function (a,b) {
+                               return {ctor: "NativeProperty",_0: a,_1: b};
+                            });
+       var on = F3(function (name,decoder,toMessage) {
+                   var handler = A2(nativeEventHandler,decoder,toMessage);
+                   var fullName = A2($Basics._op["++"],"on",name);
+                   return A2(NativeProperty,fullName,handler);
+                });
+       var onPress = F2(function (address,msg) {
+                        return A3(on
+                                 ,"Press"
+                                 ,$Json$Decode.value
+                                 ,function (_p0) {
+                                    return A2($Signal.message,address,msg);
+                                 });
+                     });
+       var JsonProperty = F2(function (a,b) {
+                             return {ctor: "JsonProperty",_0: a,_1: b};
+                          });
+       var property = F2(function (name,value) {
+                         return A2(JsonProperty,name,value);
+                      });
+       var imageSource = function (uri) {
+          return A2(property
+                   ,"source"
+                   ,$Json$Encode.object(_U.list([{ctor: "_Tuple2"
+                                                 ,_0: "uri"
+                                                 ,_1: $Json$Encode.string(uri)}])));
+       };
+       var style = function (styles) {
+          return A2(property,"style",$ReactNative$Style.encode(styles));
+       };
+       var VString = function (a) { return {ctor: "VString",_0: a};};
+       var string = VString;
+       var VNode = F3(function (a,b,c) {
+                      return {ctor: "VNode",_0: a,_1: b,_2: c};
+                   });
+       var node = F3(function (tagName,props,children) {
+                     return A3(VNode,tagName,props,children);
+                  });
+       var view = VNode("View");
+       var text = VNode("Text");
+       var image = VNode("Image");
+       return _elm.ReactNative.ReactNative.values = {_op: _op
+                                                    ,node: node
+                                                    ,string: string
+                                                    ,view: view
+                                                    ,text: text
+                                                    ,image: image
+                                                    ,style: style
+                                                    ,imageSource: imageSource
+                                                    ,onPress: onPress};
+    };
 Elm.ReactNative = Elm.ReactNative || {};
 Elm.ReactNative.NativeApp = Elm.ReactNative.NativeApp || {};
 Elm.ReactNative.NativeApp.make = function (_elm) {
-   "use strict";
-   _elm.ReactNative = _elm.ReactNative || {};
-   _elm.ReactNative.NativeApp = _elm.ReactNative.NativeApp || {};
-   if (_elm.ReactNative.NativeApp.values) return _elm.ReactNative.NativeApp.values;
-   var _U = Elm.Native.Utils.make(_elm),
-   $Basics = Elm.Basics.make(_elm),
-   $Debug = Elm.Debug.make(_elm),
-   $List = Elm.List.make(_elm),
-   $Maybe = Elm.Maybe.make(_elm),
-   $ReactNative$ReactNative = Elm.ReactNative.ReactNative.make(_elm),
-   $Result = Elm.Result.make(_elm),
-   $Signal = Elm.Signal.make(_elm);
-   var _op = {};
-   var Config = F3(function (a,b,c) {    return {model: a,view: b,update: c};});
-   var ConfigAction = function (a) {    return {ctor: "ConfigAction",_0: a};};
-   var start = function (config) {
-      var normalUpdate = F2(function (maybeAction,model) {
-         var _p0 = maybeAction;
-         if (_p0.ctor === "Just") {
-               return A2(config.update,_p0._0,model);
-            } else {
-               return _U.crashCase("ReactNative.NativeApp",{start: {line: 39,column: 7},end: {line: 44,column: 52}},_p0)("This should never happen.");
-            }
-      });
-      var update = F2(function (action,model) {
-         var _p2 = action;
-         if (_p2.ctor === "ConfigAction") {
-               return A2(normalUpdate,_p2._0,model);
-            } else {
-               return model;
-            }
-      });
-      var actions = $Signal.mailbox($Maybe.Nothing);
-      var merged = $Signal.mergeMany(_U.list([A2($Signal.map,ConfigAction,actions.signal)]));
-      var model = A3($Signal.foldp,update,config.model,merged);
-      var address = A2($Signal.forwardTo,actions.address,$Maybe.Just);
-      return A2($Signal.map,config.view(address),model);
-   };
-   var Init = {ctor: "Init"};
-   return _elm.ReactNative.NativeApp.values = {_op: _op,start: start};
-};
+       "use strict";
+       _elm.ReactNative = _elm.ReactNative || {};
+       _elm.ReactNative.NativeApp = _elm.ReactNative.NativeApp || {};
+       if (_elm.ReactNative.NativeApp.values)
+          return _elm.ReactNative.NativeApp.values;
+       var _U = Elm.Native.Utils.make(_elm),
+       $Basics = Elm.Basics.make(_elm),
+       $Debug = Elm.Debug.make(_elm),
+       $List = Elm.List.make(_elm),
+       $Maybe = Elm.Maybe.make(_elm),
+       $ReactNative$ReactNative =
+       Elm.ReactNative.ReactNative.make(_elm),
+       $Result = Elm.Result.make(_elm),
+       $Signal = Elm.Signal.make(_elm);
+       var _op = {};
+       var Config = F3(function (a,b,c) {
+                       return {model: a,view: b,update: c};
+                    });
+       var ConfigAction = function (a) {
+          return {ctor: "ConfigAction",_0: a};
+       };
+       var start = function (config) {
+          var normalUpdate = F2(function (maybeAction,model) {
+                                var _p0 = maybeAction;
+                                if (_p0.ctor === "Just") {
+                                   return A2(config.update,_p0._0,model);
+                                } else {
+                                   return _U.crashCase("ReactNative.NativeApp"
+                                                      ,{start: {line: 39,column: 7},end: {line: 44,column: 52}}
+                                                      ,_p0)("This should never happen.");
+                                }
+                             });
+          var update = F2(function (action,model) {
+                          var _p2 = action;
+                          if (_p2.ctor === "ConfigAction") {
+                             return A2(normalUpdate,_p2._0,model);
+                          } else {
+                             return model;
+                          }
+                       });
+          var actions = $Signal.mailbox($Maybe.Nothing);
+          var merged = $Signal.mergeMany(_U.list([A2($Signal.map
+                                                    ,ConfigAction
+                                                    ,actions.signal)]));
+          var model = A3($Signal.foldp,update,config.model,merged);
+          var address = A2($Signal.forwardTo,actions.address,$Maybe.Just);
+          return A2($Signal.map,config.view(address),model);
+       };
+       var Init = {ctor: "Init"};
+       return _elm.ReactNative.NativeApp.values = {_op: _op
+                                                  ,start: start};
+    };
 Elm.Main = Elm.Main || {};
 Elm.Main.make = function (_elm) {
        "use strict";

--- a/elm.js
+++ b/elm.js
@@ -8850,44 +8850,50 @@ Elm.Native.ReactNative.make = function(localRuntime) {
     function vtreeToReactElement(vtree) {
       switch (vtree.ctor) {
         case 'VString':
+        {
           return vtree._0;
-        case 'VNode': {
-          let tagName = vtree._0;
-          let propertyList = vtree._1;
-          let childNodes = vtree._2;
-
-          let reactClass = React[tagName];
-          let props = propertyListToJS(propertyList);
-          let children = List.toArray(childNodes).map(vtreeToReactElement);
-
-          return React.createElement(reactClass, props, ...children);
         }
+        case 'VNode':
+        {
+          var tagName = vtree._0;
+          var propertyList = vtree._1;
+          var childNodes = vtree._2;
+
+          var reactClass = React[tagName];
+          var props = propertyListToObject(propertyList);
+          var children = List.toArray(childNodes).map(vtreeToReactElement);
+
+          var args = [reactClass, props].concat(children);
+          return React.createElement.apply(null, args);
+        }
+        default:
+          throw new Error("I don't know how to render a VTree of type '" + vtree.ctor + "'\n" +
+            "If you've recently added a new type of VTree, you must add a new case to\n" +
+            "the switch statement in Native.ReactNative.vtreeToReactElement()");
       }
     }
 
-    function propertyToJS(property) {
-      console.log('converting RN property: ', property);
-
+    function propertyToObject(property) {
       if (property.ctor !== 'JsonProperty' &&
           property.ctor !== 'NativeProperty') {
-        return undefined;
+        throw new Error("I don't know how to handle a Property of type '" + property.ctor + "'\n" +
+          "If you've recently added a new type of Property, you must edit the\n" +
+          "propertyToObject() function in Native.ReactiNative.js");
       }
 
       return {
         key: property._0,
         value: property._1,
-      }
+      };
     }
 
-    function propertyListToJS(list)
+    function propertyListToObject(list)
   	{
   		var object = {};
   		while (list.ctor !== '[]')
   		{
-  			var entry = propertyToJS(list._0);
-        if (entry) {
-  			  object[entry.key] = entry.value;
-        }
+  			var entry = propertyToObject(list._0);
+  			object[entry.key] = entry.value;
   			list = list._1;
   		}
   		return object;
@@ -8898,8 +8904,6 @@ Elm.Native.ReactNative.make = function(localRuntime) {
     }
 
     function setReactVTree(reactElement, vtree) {
-      console.info('updating vtree: ', vtree);
-
 			var newState = Object.assign({},
 				reactElement.state,
 				{_elmVTree: vtreeToReactElement(vtree)}
@@ -8924,134 +8928,98 @@ Elm.Native.ReactNative.make = function(localRuntime) {
 Elm.ReactNative = Elm.ReactNative || {};
 Elm.ReactNative.ReactNative = Elm.ReactNative.ReactNative || {};
 Elm.ReactNative.ReactNative.make = function (_elm) {
-       "use strict";
-       _elm.ReactNative = _elm.ReactNative || {};
-       _elm.ReactNative.ReactNative = _elm.ReactNative.ReactNative ||
-           {};
-       if (_elm.ReactNative.ReactNative.values)
-          return _elm.ReactNative.ReactNative.values;
-       var _U = Elm.Native.Utils.make(_elm),
-       $Basics = Elm.Basics.make(_elm),
-       $Debug = Elm.Debug.make(_elm),
-       $Json$Decode = Elm.Json.Decode.make(_elm),
-       $Json$Encode = Elm.Json.Encode.make(_elm),
-       $List = Elm.List.make(_elm),
-       $Maybe = Elm.Maybe.make(_elm),
-       $Native$ReactNative = Elm.Native.ReactNative.make(_elm),
-       $ReactNative$Style = Elm.ReactNative.Style.make(_elm),
-       $Result = Elm.Result.make(_elm),
-       $Signal = Elm.Signal.make(_elm);
-       var _op = {};
-       var nativeEventHandler = $Native$ReactNative.nativeEventHandler;
-       var NativeValue = {ctor: "NativeValue"};
-       var NativeProperty = F2(function (a,b) {
-                               return {ctor: "NativeProperty",_0: a,_1: b};
-                            });
-       var on = F3(function (name,decoder,toMessage) {
-                   var handler = A2(nativeEventHandler,decoder,toMessage);
-                   var fullName = A2($Basics._op["++"],"on",name);
-                   return A2(NativeProperty,fullName,handler);
-                });
-       var onPress = F2(function (address,msg) {
-                        return A3(on
-                                 ,"Press"
-                                 ,$Json$Decode.value
-                                 ,function (_p0) {
-                                    return A2($Signal.message,address,msg);
-                                 });
-                     });
-       var JsonProperty = F2(function (a,b) {
-                             return {ctor: "JsonProperty",_0: a,_1: b};
-                          });
-       var property = JsonProperty;
-       var imageSource = function (uri) {
-          return A2(property
-                   ,"source"
-                   ,$Json$Encode.object(_U.list([{ctor: "_Tuple2"
-                                                 ,_0: "uri"
-                                                 ,_1: $Json$Encode.string(uri)}])));
-       };
-       var style = function (styles) {
-          return A2(property,"style",$ReactNative$Style.encode(styles));
-       };
-       var VString = function (a) { return {ctor: "VString",_0: a};};
-       var string = VString;
-       var VNode = F3(function (a,b,c) {
-                      return {ctor: "VNode",_0: a,_1: b,_2: c};
-                   });
-       var node = F3(function (tagName,props,children) {
-                     return A3(VNode,tagName,props,children);
-                  });
-       var view = VNode("View");
-       var text = VNode("Text");
-       var image = F2(function (props,source) {
-                      return A3(VNode,"Image",props,source);
-                   });
-       return _elm.ReactNative.ReactNative.values = {_op: _op
-                                                    ,node: node
-                                                    ,string: string
-                                                    ,view: view
-                                                    ,text: text
-                                                    ,image: image
-                                                    ,style: style
-                                                    ,imageSource: imageSource
-                                                    ,onPress: onPress};
-    };
+   "use strict";
+   _elm.ReactNative = _elm.ReactNative || {};
+   _elm.ReactNative.ReactNative = _elm.ReactNative.ReactNative || {};
+   if (_elm.ReactNative.ReactNative.values) return _elm.ReactNative.ReactNative.values;
+   var _U = Elm.Native.Utils.make(_elm),
+   $Basics = Elm.Basics.make(_elm),
+   $Debug = Elm.Debug.make(_elm),
+   $Json$Decode = Elm.Json.Decode.make(_elm),
+   $Json$Encode = Elm.Json.Encode.make(_elm),
+   $List = Elm.List.make(_elm),
+   $Maybe = Elm.Maybe.make(_elm),
+   $Native$ReactNative = Elm.Native.ReactNative.make(_elm),
+   $ReactNative$Style = Elm.ReactNative.Style.make(_elm),
+   $Result = Elm.Result.make(_elm),
+   $Signal = Elm.Signal.make(_elm);
+   var _op = {};
+   var nativeEventHandler = $Native$ReactNative.nativeEventHandler;
+   var NativeValue = {ctor: "NativeValue"};
+   var NativeProperty = F2(function (a,b) {    return {ctor: "NativeProperty",_0: a,_1: b};});
+   var on = F3(function (name,decoder,toMessage) {
+      var handler = A2(nativeEventHandler,decoder,toMessage);
+      var fullName = A2($Basics._op["++"],"on",name);
+      return A2(NativeProperty,fullName,handler);
+   });
+   var onPress = F2(function (address,msg) {    return A3(on,"Press",$Json$Decode.value,function (_p0) {    return A2($Signal.message,address,msg);});});
+   var JsonProperty = F2(function (a,b) {    return {ctor: "JsonProperty",_0: a,_1: b};});
+   var property = JsonProperty;
+   var imageSource = function (uri) {
+      return A2(property,"source",$Json$Encode.object(_U.list([{ctor: "_Tuple2",_0: "uri",_1: $Json$Encode.string(uri)}])));
+   };
+   var style = function (styles) {    return A2(property,"style",$ReactNative$Style.encode(styles));};
+   var VString = function (a) {    return {ctor: "VString",_0: a};};
+   var string = VString;
+   var VNode = F3(function (a,b,c) {    return {ctor: "VNode",_0: a,_1: b,_2: c};});
+   var node = F3(function (tagName,props,children) {    return A3(VNode,tagName,props,children);});
+   var view = VNode("View");
+   var text = VNode("Text");
+   var image = F2(function (props,source) {    return A3(VNode,"Image",props,source);});
+   return _elm.ReactNative.ReactNative.values = {_op: _op
+                                                ,node: node
+                                                ,string: string
+                                                ,view: view
+                                                ,text: text
+                                                ,image: image
+                                                ,style: style
+                                                ,imageSource: imageSource
+                                                ,onPress: onPress};
+};
 Elm.ReactNative = Elm.ReactNative || {};
 Elm.ReactNative.NativeApp = Elm.ReactNative.NativeApp || {};
 Elm.ReactNative.NativeApp.make = function (_elm) {
-       "use strict";
-       _elm.ReactNative = _elm.ReactNative || {};
-       _elm.ReactNative.NativeApp = _elm.ReactNative.NativeApp || {};
-       if (_elm.ReactNative.NativeApp.values)
-          return _elm.ReactNative.NativeApp.values;
-       var _U = Elm.Native.Utils.make(_elm),
-       $Basics = Elm.Basics.make(_elm),
-       $Debug = Elm.Debug.make(_elm),
-       $List = Elm.List.make(_elm),
-       $Maybe = Elm.Maybe.make(_elm),
-       $ReactNative$ReactNative =
-       Elm.ReactNative.ReactNative.make(_elm),
-       $Result = Elm.Result.make(_elm),
-       $Signal = Elm.Signal.make(_elm);
-       var _op = {};
-       var Config = F3(function (a,b,c) {
-                       return {model: a,view: b,update: c};
-                    });
-       var ConfigAction = function (a) {
-          return {ctor: "ConfigAction",_0: a};
-       };
-       var start = function (config) {
-          var normalUpdate = F2(function (maybeAction,model) {
-                                var _p0 = maybeAction;
-                                if (_p0.ctor === "Just") {
-                                   return A2(config.update,_p0._0,model);
-                                } else {
-                                   return _U.crashCase("ReactNative.NativeApp"
-                                                      ,{start: {line: 39,column: 7},end: {line: 44,column: 52}}
-                                                      ,_p0)("This should never happen.");
-                                }
-                             });
-          var update = F2(function (action,model) {
-                          var _p2 = action;
-                          if (_p2.ctor === "ConfigAction") {
-                             return A2(normalUpdate,_p2._0,model);
-                          } else {
-                             return model;
-                          }
-                       });
-          var actions = $Signal.mailbox($Maybe.Nothing);
-          var merged = $Signal.mergeMany(_U.list([A2($Signal.map
-                                                    ,ConfigAction
-                                                    ,actions.signal)]));
-          var model = A3($Signal.foldp,update,config.model,merged);
-          var address = A2($Signal.forwardTo,actions.address,$Maybe.Just);
-          return A2($Signal.map,config.view(address),model);
-       };
-       var Init = {ctor: "Init"};
-       return _elm.ReactNative.NativeApp.values = {_op: _op
-                                                  ,start: start};
-    };
+   "use strict";
+   _elm.ReactNative = _elm.ReactNative || {};
+   _elm.ReactNative.NativeApp = _elm.ReactNative.NativeApp || {};
+   if (_elm.ReactNative.NativeApp.values) return _elm.ReactNative.NativeApp.values;
+   var _U = Elm.Native.Utils.make(_elm),
+   $Basics = Elm.Basics.make(_elm),
+   $Debug = Elm.Debug.make(_elm),
+   $List = Elm.List.make(_elm),
+   $Maybe = Elm.Maybe.make(_elm),
+   $ReactNative$ReactNative = Elm.ReactNative.ReactNative.make(_elm),
+   $Result = Elm.Result.make(_elm),
+   $Signal = Elm.Signal.make(_elm);
+   var _op = {};
+   var Config = F3(function (a,b,c) {    return {model: a,view: b,update: c};});
+   var ConfigAction = function (a) {    return {ctor: "ConfigAction",_0: a};};
+   var start = function (config) {
+      var normalUpdate = F2(function (maybeAction,model) {
+         var _p0 = maybeAction;
+         if (_p0.ctor === "Just") {
+               return A2(config.update,_p0._0,model);
+            } else {
+               return _U.crashCase("ReactNative.NativeApp",{start: {line: 39,column: 7},end: {line: 44,column: 52}},_p0)("This should never happen.");
+            }
+      });
+      var update = F2(function (action,model) {
+         var _p2 = action;
+         if (_p2.ctor === "ConfigAction") {
+               return A2(normalUpdate,_p2._0,model);
+            } else {
+               return model;
+            }
+      });
+      var actions = $Signal.mailbox($Maybe.Nothing);
+      var merged = $Signal.mergeMany(_U.list([A2($Signal.map,ConfigAction,actions.signal)]));
+      var model = A3($Signal.foldp,update,config.model,merged);
+      var address = A2($Signal.forwardTo,actions.address,$Maybe.Just);
+      return A2($Signal.map,config.view(address),model);
+   };
+   var Init = {ctor: "Init"};
+   return _elm.ReactNative.NativeApp.values = {_op: _op,start: start};
+};
 Elm.Main = Elm.Main || {};
 Elm.Main.make = function (_elm) {
        "use strict";

--- a/elm.js
+++ b/elm.js
@@ -1281,6 +1281,75 @@ if (!Elm.fullscreen) {
 			return init(Display.NONE, {}, module, args || {});
 		};
 
+		Elm.embedReact = function(module, containerElement, reactEnvironment, args)
+		{
+			if ((typeof reactEnvironment !== 'object') ||
+			  	(typeof reactEnvironment.React !== 'object'))
+			{
+				throw new Error(
+					"Elm.embedReact() requires at least three arguments:\n" +
+					"1: the Elm module you want to run e.g. `Elm.Main`\n" +
+					"2: an instantiated React element to conain the app\n" +
+					"3: an object containing a field named `React` whose value is\n" +
+					"   the output of `require('react-native')`.\n" +
+					"   If you want non-standard components to be accessible to Elm,\n" +
+					"   you can `require` them into this object." +
+					"   For example: \n" +
+					"     {\n" +
+					"       React: require('react-native'),\n" +
+					"       MyComponents: {\n" +
+					"         Awesome: // require your component here...\n " +
+					"       }\n" +
+					"     }\n" +
+					"   With the above, you could write an Elm function for the Awesome component: \n" +
+					"     awesome : List ReactNative.Property -> List ReactNative.Node -> ReactNative.Node\n"+
+					"     awesome = ReactNative.Node \"MyComponents.Awesome\"\n" +
+					"4: the fourth argument is an optional object containing inputs to your Elm program.\n" +
+					"   it is equivalent to the final argument of `Elm.fullscreen` or `Elm.embed`"
+				);
+			}
+
+			function isReactElement(maybeElement) {
+				return maybeElement['$$typeof'] === Symbol.for('react.element');
+			}
+
+			function setReactVTree(reactElement, vtree) {
+				var newState = Object.assign({},
+					reactElement.state,
+					{_elmVTree: vtree}
+				);
+
+				console.log('setting state of react element: ', reactElement);
+				console.log('new state: ', newState);
+				reactElement.setState(newState);
+			}
+
+			function displayReactError(message) {
+				// TODO: bring up the RedBox with the error message
+				console.error(message);
+			}
+
+			var container = {
+				reactEnvironment: reactEnvironment,
+				firstChild: containerElement,
+				appendChild: function (child) {
+					this.firstChild = containerElement;
+					if (isReactElement(child)) {
+						setReactVTree(containerElement, child);
+						return child;
+					} else {
+						console.warn('appendChild called on React container with non-React element: ', child);
+					}
+				},
+				removeChild: function() {
+					this.firstChild = null;
+				},
+				displayReactError: displayReactError,
+			}
+
+			init(Display.COMPONENT, container, module, args || {});
+		}
+
 		function init(display, container, module, args, moduleToReplace)
 		{
 			// defining state needed for an instance of the Elm RTS
@@ -1385,7 +1454,10 @@ if (!Elm.fullscreen) {
 			}
 			catch (error)
 			{
-				if (typeof container.appendChild === "function")
+				if (typeof container.displayReactError === 'function') {
+					container.displayReactError(error.message);
+				}
+				else if (typeof container.appendChild === "function")
 				{
 					container.appendChild(errorNode(error.message));
 				}
@@ -1571,9 +1643,19 @@ if (!Elm.fullscreen) {
 			}
 			else
 			{
-				var VirtualDom = Elm.Native.VirtualDom.make(elm);
-				render = VirtualDom.render;
-				update = VirtualDom.updateAndReplace;
+				if (typeof Elm.Native.ReactNative !== 'undefined') {
+					var ReactNative = Elm.Native.ReactNative.make(elm);
+					render = ReactNative.render;
+					update = ReactNative.updateAndReplace;
+				} else if (typeof Elm.Native.VirtualDom !== 'undefined') {
+					VirtualDom = Elm.Native.VirtualDom.make(elm);
+					render = VirtualDom.render;
+					update = VirtualDom.updateAndReplace;
+				} else {
+					throw new Error(
+						"It looks like you'd like to render with either React Native\n" +
+						"or VirtualDom, but I can't find either in the Elm.Native runtime.");
+				}
 			}
 
 			// Add the initialScene to the DOM
@@ -6594,7 +6676,7 @@ Elm.Signal.make = function (_elm) {
    var mergeMany = function (signalList) {
       var _p7 = $List.reverse(signalList);
       if (_p7.ctor === "[]") {
-            return _U.crashCase("Signal",{start: {line: 184,column: 3},end: {line: 189,column: 40}},_p7)("mergeMany was given an empty list!");
+            return _U.crashCase("Signal",{start: {line: 189,column: 3},end: {line: 194,column: 40}},_p7)("mergeMany was given an empty list!");
          } else {
             return A3($List.foldl,merge,_p7._0,_p7._1);
          }
@@ -8288,276 +8370,354 @@ Elm.Json.Decode.make = function (_elm) {
 Elm.ReactNative = Elm.ReactNative || {};
 Elm.ReactNative.Style = Elm.ReactNative.Style || {};
 Elm.ReactNative.Style.make = function (_elm) {
-   "use strict";
-   _elm.ReactNative = _elm.ReactNative || {};
-   _elm.ReactNative.Style = _elm.ReactNative.Style || {};
-   if (_elm.ReactNative.Style.values) return _elm.ReactNative.Style.values;
-   var _U = Elm.Native.Utils.make(_elm),
-   $Basics = Elm.Basics.make(_elm),
-   $Debug = Elm.Debug.make(_elm),
-   $Json$Encode = Elm.Json.Encode.make(_elm),
-   $List = Elm.List.make(_elm),
-   $Maybe = Elm.Maybe.make(_elm),
-   $Result = Elm.Result.make(_elm),
-   $Signal = Elm.Signal.make(_elm);
-   var _op = {};
-   var defaultTransform = {perspective: $Maybe.Nothing
-                          ,rotate: $Maybe.Nothing
-                          ,rotateX: $Maybe.Nothing
-                          ,rotateY: $Maybe.Nothing
-                          ,rotateZ: $Maybe.Nothing
-                          ,scale: $Maybe.Nothing
-                          ,scaleX: $Maybe.Nothing
-                          ,scaleY: $Maybe.Nothing
-                          ,translateX: $Maybe.Nothing
-                          ,translateY: $Maybe.Nothing
-                          ,skewX: $Maybe.Nothing
-                          ,skewY: $Maybe.Nothing};
-   var Transform = function (a) {
-      return function (b) {
-         return function (c) {
-            return function (d) {
-               return function (e) {
-                  return function (f) {
-                     return function (g) {
-                        return function (h) {
-                           return function (i) {
-                              return function (j) {
-                                 return function (k) {
-                                    return function (l) {
-                                       return {perspective: a
-                                              ,rotate: b
-                                              ,rotateX: c
-                                              ,rotateY: d
-                                              ,rotateZ: e
-                                              ,scale: f
-                                              ,scaleX: g
-                                              ,scaleY: h
-                                              ,translateX: i
-                                              ,translateY: j
-                                              ,skewX: k
-                                              ,skewY: l};
-                                    };
-                                 };
-                              };
-                           };
-                        };
+       "use strict";
+       _elm.ReactNative = _elm.ReactNative || {};
+       _elm.ReactNative.Style = _elm.ReactNative.Style || {};
+       if (_elm.ReactNative.Style.values)
+          return _elm.ReactNative.Style.values;
+       var _U = Elm.Native.Utils.make(_elm),
+       $Basics = Elm.Basics.make(_elm),
+       $Debug = Elm.Debug.make(_elm),
+       $Json$Encode = Elm.Json.Encode.make(_elm),
+       $List = Elm.List.make(_elm),
+       $Maybe = Elm.Maybe.make(_elm),
+       $Result = Elm.Result.make(_elm),
+       $Signal = Elm.Signal.make(_elm);
+       var _op = {};
+       var defaultTransform = {perspective: $Maybe.Nothing
+                              ,rotate: $Maybe.Nothing
+                              ,rotateX: $Maybe.Nothing
+                              ,rotateY: $Maybe.Nothing
+                              ,rotateZ: $Maybe.Nothing
+                              ,scale: $Maybe.Nothing
+                              ,scaleX: $Maybe.Nothing
+                              ,scaleY: $Maybe.Nothing
+                              ,translateX: $Maybe.Nothing
+                              ,translateY: $Maybe.Nothing
+                              ,skewX: $Maybe.Nothing
+                              ,skewY: $Maybe.Nothing};
+       var Transform = function (a) {
+          return function (b) {
+                 return function (c) {
+                        return function (d) {
+                               return function (e) {
+                                      return function (f) {
+                                             return function (g) {
+                                                    return function (h) {
+                                                           return function (i) {
+                                                                  return function (j) {
+                                                                         return function (k) {
+                                                                                return function (l) {
+                                                                                       return {perspective: a
+                                                                                              ,rotate: b
+                                                                                              ,rotateX: c
+                                                                                              ,rotateY: d
+                                                                                              ,rotateZ: e
+                                                                                              ,scale: f
+                                                                                              ,scaleX: g
+                                                                                              ,scaleY: h
+                                                                                              ,translateX: i
+                                                                                              ,translateY: j
+                                                                                              ,skewX: k
+                                                                                              ,skewY: l};
+                                                                                    };
+                                                                             };
+                                                                      };
+                                                               };
+                                                        };
+                                                 };
+                                          };
+                                   };
+                            };
                      };
-                  };
-               };
-            };
-         };
-      };
-   };
-   var encodeValue = function (value) {
-      var _p0 = value;
-      switch (_p0.ctor)
-      {case "NumberValue": return $Json$Encode.$float(_p0._0);
-         case "StringValue": return $Json$Encode.string(_p0._0);
-         case "ObjectValue": return $Json$Encode.object(A2($List.map,encodeDeclaration,_p0._0));
-         default: return $Json$Encode.list(A2($List.map,encodeObject,A2($List.filterMap,$Basics.identity,_p0._0)));}
-   };
-   var encodeDeclaration = function (_p1) {    var _p2 = _p1;return {ctor: "_Tuple2",_0: _p2._0,_1: encodeValue(_p2._1)};};
-   var encodeObject = function (_p3) {    var _p4 = _p3;return $Json$Encode.object(_U.list([{ctor: "_Tuple2",_0: _p4._0,_1: encodeValue(_p4._1)}]));};
-   var toJsonProperty = function (style) {
-      var _p5 = style;
-      switch (_p5.ctor)
-      {case "StringStyle": return {ctor: "_Tuple2",_0: _p5._0._0,_1: encodeValue(_p5._0._1)};
-         case "NumberStyle": return {ctor: "_Tuple2",_0: _p5._0._0,_1: encodeValue(_p5._0._1)};
-         case "ObjectStyle": return {ctor: "_Tuple2",_0: _p5._0._0,_1: encodeValue(_p5._0._1)};
-         default: return {ctor: "_Tuple2",_0: _p5._0._0,_1: encodeValue(_p5._0._1)};}
-   };
-   var encode = function (styles) {    return $Json$Encode.object(A2($List.map,toJsonProperty,styles));};
-   var ListStyle = function (a) {    return {ctor: "ListStyle",_0: a};};
-   var ObjectStyle = function (a) {    return {ctor: "ObjectStyle",_0: a};};
-   var NumberStyle = function (a) {    return {ctor: "NumberStyle",_0: a};};
-   var StringStyle = function (a) {    return {ctor: "StringStyle",_0: a};};
-   var ListValue = function (a) {    return {ctor: "ListValue",_0: a};};
-   var listDeclaration = F2(function (name,value) {    return {ctor: "_Tuple2",_0: name,_1: ListValue(value)};});
-   var listStyle = F2(function (name,list) {    return ListStyle(A2(listDeclaration,name,list));});
-   var ObjectValue = function (a) {    return {ctor: "ObjectValue",_0: a};};
-   var objectDeclaration = F2(function (name,value) {    return {ctor: "_Tuple2",_0: name,_1: ObjectValue(value)};});
-   var objectStyle = F2(function (name,list) {    return ObjectStyle(A2(objectDeclaration,name,list));});
-   var NumberValue = function (a) {    return {ctor: "NumberValue",_0: a};};
-   var numberDeclaration = F2(function (name,value) {    return {ctor: "_Tuple2",_0: name,_1: NumberValue(value)};});
-   var numberStyle = F2(function (name,value) {    return NumberStyle(A2(numberDeclaration,name,value));});
-   var fontSize = numberStyle("fontSize");
-   var letterSpacing = numberStyle("letterSpacing");
-   var lineHeight = numberStyle("lineHeight");
-   var borderRadius = numberStyle("borderRadius");
-   var borderTopLeftRadius = numberStyle("borderTopLeftRadius");
-   var borderTopRightRadius = numberStyle("borderTopRightRadius");
-   var borderBottomLeftRadius = numberStyle("borderBottomLeftRadius");
-   var borderBottomRightRadius = numberStyle("borderBottomRightRadius");
-   var borderWidth = numberStyle("borderWidth");
-   var borderTopWidth = numberStyle("borderTopWidth");
-   var borderRightWidth = numberStyle("borderRightWidth");
-   var borderBottomWidth = numberStyle("borderBottomWidth");
-   var borderLeftWidth = numberStyle("borderLeftWidth");
-   var opacity = numberStyle("opacity");
-   var shadowOpacity = numberStyle("shadowOpacity");
-   var shadowRadius = numberStyle("shadowRadius");
-   var bottom = numberStyle("bottom");
-   var flex = numberStyle("flex");
-   var height = numberStyle("height");
-   var left = numberStyle("left");
-   var margin = numberStyle("margin");
-   var marginBottom = numberStyle("marginBottom");
-   var marginHorizontal = numberStyle("marginHorizontal");
-   var marginLeft = numberStyle("marginLeft");
-   var marginRight = numberStyle("marginRight");
-   var marginTop = numberStyle("marginTop");
-   var marginVertical = numberStyle("marginVertical");
-   var padding = numberStyle("padding");
-   var paddingBottom = numberStyle("paddingBottom");
-   var paddingHorizontal = numberStyle("paddingHorizontal");
-   var paddingLeft = numberStyle("paddingLeft");
-   var paddingRight = numberStyle("paddingRight");
-   var paddingTop = numberStyle("paddingTop");
-   var paddingVertical = numberStyle("paddingVertical");
-   var right = numberStyle("right");
-   var top = numberStyle("top");
-   var width = numberStyle("width");
-   var shadowOffset = F2(function (width,height) {
-      return A2(objectStyle,"shadowOffset",_U.list([A2(numberDeclaration,"width",width),A2(numberDeclaration,"height",height)]));
-   });
-   var StringValue = function (a) {    return {ctor: "StringValue",_0: a};};
-   var stringDeclaration = F2(function (name,value) {    return {ctor: "_Tuple2",_0: name,_1: StringValue(value)};});
-   var stringStyle = F2(function (name,value) {    return StringStyle(A2(stringDeclaration,name,value));});
-   var color = stringStyle("color");
-   var fontFamily = stringStyle("fontFamily");
-   var fontStyle = stringStyle("fontStyle");
-   var fontWeight = stringStyle("fontWeight");
-   var textAlign = stringStyle("textAlign");
-   var textDecorationLine = stringStyle("textDecorationLine");
-   var textDecorationStyle = stringStyle("textDecorationStyle");
-   var textDecorationColor = stringStyle("textDecorationColor");
-   var writingDirection = stringStyle("writingDirection");
-   var backfaceVisibility = stringStyle("backfaceVisibility");
-   var backgroundColor = stringStyle("backgroundColor");
-   var borderColor = stringStyle("borderColor");
-   var borderTopColor = stringStyle("borderTopColor");
-   var borderRightColor = stringStyle("borderRightColor");
-   var borderBottomColor = stringStyle("borderBottomColor");
-   var borderLeftColor = stringStyle("borderLeftColor");
-   var borderStyle = stringStyle("borderStyle");
-   var overflow = stringStyle("overflow");
-   var shadowColor = stringStyle("shadowColor");
-   var resizeMode = stringStyle("resizeMode");
-   var tintColor = stringStyle("tintColor");
-   var alignItems = stringStyle("alignItems");
-   var alignSelf = stringStyle("alignSelf");
-   var flexDirection = stringStyle("flexDirection");
-   var flexWrap = stringStyle("flexWrap");
-   var justifyContent = stringStyle("justifyContent");
-   var position = stringStyle("position");
-   var transform = function (options) {
-      return A2(listStyle,
-      "transform",
-      _U.list([A2($Maybe.map,numberDeclaration("perspective"),options.perspective)
-              ,A2($Maybe.map,stringDeclaration("rotate"),options.rotate)
-              ,A2($Maybe.map,stringDeclaration("rotateX"),options.rotateX)
-              ,A2($Maybe.map,stringDeclaration("rotateY"),options.rotateY)
-              ,A2($Maybe.map,stringDeclaration("rotateZ"),options.rotateZ)
-              ,A2($Maybe.map,numberDeclaration("scale"),options.scale)
-              ,A2($Maybe.map,numberDeclaration("scaleX"),options.scaleX)
-              ,A2($Maybe.map,numberDeclaration("scaleY"),options.scaleY)
-              ,A2($Maybe.map,numberDeclaration("translateX"),options.translateX)
-              ,A2($Maybe.map,numberDeclaration("translateY"),options.translateY)
-              ,A2($Maybe.map,stringDeclaration("skewX"),options.skewX)
-              ,A2($Maybe.map,stringDeclaration("skewY"),options.skewY)]));
-   };
-   return _elm.ReactNative.Style.values = {_op: _op
-                                          ,StringValue: StringValue
-                                          ,NumberValue: NumberValue
-                                          ,ObjectValue: ObjectValue
-                                          ,ListValue: ListValue
-                                          ,stringDeclaration: stringDeclaration
-                                          ,numberDeclaration: numberDeclaration
-                                          ,objectDeclaration: objectDeclaration
-                                          ,listDeclaration: listDeclaration
-                                          ,stringStyle: stringStyle
-                                          ,numberStyle: numberStyle
-                                          ,objectStyle: objectStyle
-                                          ,listStyle: listStyle
-                                          ,StringStyle: StringStyle
-                                          ,NumberStyle: NumberStyle
-                                          ,ObjectStyle: ObjectStyle
-                                          ,ListStyle: ListStyle
-                                          ,encodeValue: encodeValue
-                                          ,encodeDeclaration: encodeDeclaration
-                                          ,encodeObject: encodeObject
-                                          ,toJsonProperty: toJsonProperty
-                                          ,encode: encode
-                                          ,color: color
-                                          ,fontFamily: fontFamily
-                                          ,fontSize: fontSize
-                                          ,fontStyle: fontStyle
-                                          ,fontWeight: fontWeight
-                                          ,letterSpacing: letterSpacing
-                                          ,lineHeight: lineHeight
-                                          ,textAlign: textAlign
-                                          ,textDecorationLine: textDecorationLine
-                                          ,textDecorationStyle: textDecorationStyle
-                                          ,textDecorationColor: textDecorationColor
-                                          ,writingDirection: writingDirection
-                                          ,backfaceVisibility: backfaceVisibility
-                                          ,backgroundColor: backgroundColor
-                                          ,borderColor: borderColor
-                                          ,borderTopColor: borderTopColor
-                                          ,borderRightColor: borderRightColor
-                                          ,borderBottomColor: borderBottomColor
-                                          ,borderLeftColor: borderLeftColor
-                                          ,borderRadius: borderRadius
-                                          ,borderTopLeftRadius: borderTopLeftRadius
-                                          ,borderTopRightRadius: borderTopRightRadius
-                                          ,borderBottomLeftRadius: borderBottomLeftRadius
-                                          ,borderBottomRightRadius: borderBottomRightRadius
-                                          ,borderStyle: borderStyle
-                                          ,borderWidth: borderWidth
-                                          ,borderTopWidth: borderTopWidth
-                                          ,borderRightWidth: borderRightWidth
-                                          ,borderBottomWidth: borderBottomWidth
-                                          ,borderLeftWidth: borderLeftWidth
-                                          ,opacity: opacity
-                                          ,overflow: overflow
-                                          ,shadowColor: shadowColor
-                                          ,shadowOffset: shadowOffset
-                                          ,shadowOpacity: shadowOpacity
-                                          ,shadowRadius: shadowRadius
-                                          ,resizeMode: resizeMode
-                                          ,tintColor: tintColor
-                                          ,alignItems: alignItems
-                                          ,alignSelf: alignSelf
-                                          ,bottom: bottom
-                                          ,flex: flex
-                                          ,flexDirection: flexDirection
-                                          ,flexWrap: flexWrap
-                                          ,height: height
-                                          ,justifyContent: justifyContent
-                                          ,left: left
-                                          ,margin: margin
-                                          ,marginBottom: marginBottom
-                                          ,marginHorizontal: marginHorizontal
-                                          ,marginLeft: marginLeft
-                                          ,marginRight: marginRight
-                                          ,marginTop: marginTop
-                                          ,marginVertical: marginVertical
-                                          ,padding: padding
-                                          ,paddingBottom: paddingBottom
-                                          ,paddingHorizontal: paddingHorizontal
-                                          ,paddingLeft: paddingLeft
-                                          ,paddingRight: paddingRight
-                                          ,paddingTop: paddingTop
-                                          ,paddingVertical: paddingVertical
-                                          ,position: position
-                                          ,right: right
-                                          ,top: top
-                                          ,width: width
-                                          ,Transform: Transform
-                                          ,defaultTransform: defaultTransform
-                                          ,transform: transform};
-};
+              };
+       };
+       var encodeValue = function (value) {
+          var _p0 = value;
+          switch (_p0.ctor)
+          {
+            case "NumberValue":
+              return $Json$Encode.$float(_p0._0);
+            case "StringValue":
+              return $Json$Encode.string(_p0._0);
+            case "ObjectValue":
+              return $Json$Encode.object(A2($List.map
+                                           ,encodeDeclaration
+                                           ,_p0._0));
+            default:
+              return $Json$Encode.list(A2($List.map
+                                         ,encodeObject
+                                         ,A2($List.filterMap,$Basics.identity,_p0._0)));
+          }
+       };
+       var encodeDeclaration = function (_p1) {
+          var _p2 = _p1;
+          return {ctor: "_Tuple2",_0: _p2._0,_1: encodeValue(_p2._1)};
+       };
+       var encodeObject = function (_p3) {
+          var _p4 = _p3;
+          return $Json$Encode.object(_U.list([{ctor: "_Tuple2"
+                                              ,_0: _p4._0
+                                              ,_1: encodeValue(_p4._1)}]));
+       };
+       var toJsonProperty = function (style) {
+          var _p5 = style;
+          switch (_p5.ctor)
+          {
+            case "StringStyle":
+              return {ctor: "_Tuple2"
+                     ,_0: _p5._0._0
+                     ,_1: encodeValue(_p5._0._1)};
+            case "NumberStyle":
+              return {ctor: "_Tuple2"
+                     ,_0: _p5._0._0
+                     ,_1: encodeValue(_p5._0._1)};
+            case "ObjectStyle":
+              return {ctor: "_Tuple2"
+                     ,_0: _p5._0._0
+                     ,_1: encodeValue(_p5._0._1)};
+            default:
+              return {ctor: "_Tuple2"
+                     ,_0: _p5._0._0
+                     ,_1: encodeValue(_p5._0._1)};
+          }
+       };
+       var encode = function (styles) {
+          return $Json$Encode.object(A2($List.map,toJsonProperty,styles));
+       };
+       var ListStyle = function (a) {
+          return {ctor: "ListStyle",_0: a};
+       };
+       var ObjectStyle = function (a) {
+          return {ctor: "ObjectStyle",_0: a};
+       };
+       var NumberStyle = function (a) {
+          return {ctor: "NumberStyle",_0: a};
+       };
+       var StringStyle = function (a) {
+          return {ctor: "StringStyle",_0: a};
+       };
+       var ListValue = function (a) {
+          return {ctor: "ListValue",_0: a};
+       };
+       var listDeclaration = F2(function (name,value) {
+                                return {ctor: "_Tuple2",_0: name,_1: ListValue(value)};
+                             });
+       var listStyle = F2(function (name,list) {
+                          return ListStyle(A2(listDeclaration,name,list));
+                       });
+       var ObjectValue = function (a) {
+          return {ctor: "ObjectValue",_0: a};
+       };
+       var objectDeclaration = F2(function (name,value) {
+                                  return {ctor: "_Tuple2",_0: name,_1: ObjectValue(value)};
+                               });
+       var objectStyle = F2(function (name,list) {
+                            return ObjectStyle(A2(objectDeclaration,name,list));
+                         });
+       var NumberValue = function (a) {
+          return {ctor: "NumberValue",_0: a};
+       };
+       var numberDeclaration = F2(function (name,value) {
+                                  return {ctor: "_Tuple2",_0: name,_1: NumberValue(value)};
+                               });
+       var numberStyle = F2(function (name,value) {
+                            return NumberStyle(A2(numberDeclaration,name,value));
+                         });
+       var fontSize = numberStyle("fontSize");
+       var letterSpacing = numberStyle("letterSpacing");
+       var lineHeight = numberStyle("lineHeight");
+       var borderRadius = numberStyle("borderRadius");
+       var borderTopLeftRadius = numberStyle("borderTopLeftRadius");
+       var borderTopRightRadius = numberStyle("borderTopRightRadius");
+       var borderBottomLeftRadius =
+       numberStyle("borderBottomLeftRadius");
+       var borderBottomRightRadius =
+       numberStyle("borderBottomRightRadius");
+       var borderWidth = numberStyle("borderWidth");
+       var borderTopWidth = numberStyle("borderTopWidth");
+       var borderRightWidth = numberStyle("borderRightWidth");
+       var borderBottomWidth = numberStyle("borderBottomWidth");
+       var borderLeftWidth = numberStyle("borderLeftWidth");
+       var opacity = numberStyle("opacity");
+       var shadowOpacity = numberStyle("shadowOpacity");
+       var shadowRadius = numberStyle("shadowRadius");
+       var bottom = numberStyle("bottom");
+       var flex = numberStyle("flex");
+       var height = numberStyle("height");
+       var left = numberStyle("left");
+       var margin = numberStyle("margin");
+       var marginBottom = numberStyle("marginBottom");
+       var marginHorizontal = numberStyle("marginHorizontal");
+       var marginLeft = numberStyle("marginLeft");
+       var marginRight = numberStyle("marginRight");
+       var marginTop = numberStyle("marginTop");
+       var marginVertical = numberStyle("marginVertical");
+       var padding = numberStyle("padding");
+       var paddingBottom = numberStyle("paddingBottom");
+       var paddingHorizontal = numberStyle("paddingHorizontal");
+       var paddingLeft = numberStyle("paddingLeft");
+       var paddingRight = numberStyle("paddingRight");
+       var paddingTop = numberStyle("paddingTop");
+       var paddingVertical = numberStyle("paddingVertical");
+       var right = numberStyle("right");
+       var top = numberStyle("top");
+       var width = numberStyle("width");
+       var shadowOffset = F2(function (width,height) {
+                             return A2(objectStyle
+                                      ,"shadowOffset"
+                                      ,_U.list([A2(numberDeclaration,"width",width)
+                                               ,A2(numberDeclaration,"height",height)]));
+                          });
+       var StringValue = function (a) {
+          return {ctor: "StringValue",_0: a};
+       };
+       var stringDeclaration = F2(function (name,value) {
+                                  return {ctor: "_Tuple2",_0: name,_1: StringValue(value)};
+                               });
+       var stringStyle = F2(function (name,value) {
+                            return StringStyle(A2(stringDeclaration,name,value));
+                         });
+       var color = stringStyle("color");
+       var fontFamily = stringStyle("fontFamily");
+       var fontStyle = stringStyle("fontStyle");
+       var fontWeight = stringStyle("fontWeight");
+       var textAlign = stringStyle("textAlign");
+       var textDecorationLine = stringStyle("textDecorationLine");
+       var textDecorationStyle = stringStyle("textDecorationStyle");
+       var textDecorationColor = stringStyle("textDecorationColor");
+       var writingDirection = stringStyle("writingDirection");
+       var backfaceVisibility = stringStyle("backfaceVisibility");
+       var backgroundColor = stringStyle("backgroundColor");
+       var borderColor = stringStyle("borderColor");
+       var borderTopColor = stringStyle("borderTopColor");
+       var borderRightColor = stringStyle("borderRightColor");
+       var borderBottomColor = stringStyle("borderBottomColor");
+       var borderLeftColor = stringStyle("borderLeftColor");
+       var borderStyle = stringStyle("borderStyle");
+       var overflow = stringStyle("overflow");
+       var shadowColor = stringStyle("shadowColor");
+       var resizeMode = stringStyle("resizeMode");
+       var tintColor = stringStyle("tintColor");
+       var alignItems = stringStyle("alignItems");
+       var alignSelf = stringStyle("alignSelf");
+       var flexDirection = stringStyle("flexDirection");
+       var flexWrap = stringStyle("flexWrap");
+       var justifyContent = stringStyle("justifyContent");
+       var position = stringStyle("position");
+       var transform = function (options) {
+          return A2(listStyle
+                   ,"transform"
+                   ,_U.list([A2($Maybe.map
+                               ,numberDeclaration("perspective")
+                               ,options.perspective)
+                            ,A2($Maybe.map,stringDeclaration("rotate"),options.rotate)
+                            ,A2($Maybe.map,stringDeclaration("rotateX"),options.rotateX)
+                            ,A2($Maybe.map,stringDeclaration("rotateY"),options.rotateY)
+                            ,A2($Maybe.map,stringDeclaration("rotateZ"),options.rotateZ)
+                            ,A2($Maybe.map,numberDeclaration("scale"),options.scale)
+                            ,A2($Maybe.map,numberDeclaration("scaleX"),options.scaleX)
+                            ,A2($Maybe.map,numberDeclaration("scaleY"),options.scaleY)
+                            ,A2($Maybe.map
+                               ,numberDeclaration("translateX")
+                               ,options.translateX)
+                            ,A2($Maybe.map
+                               ,numberDeclaration("translateY")
+                               ,options.translateY)
+                            ,A2($Maybe.map,stringDeclaration("skewX"),options.skewX)
+                            ,A2($Maybe.map,stringDeclaration("skewY"),options.skewY)]));
+       };
+       return _elm.ReactNative.Style.values = {_op: _op
+                                              ,StringValue: StringValue
+                                              ,NumberValue: NumberValue
+                                              ,ObjectValue: ObjectValue
+                                              ,ListValue: ListValue
+                                              ,stringDeclaration: stringDeclaration
+                                              ,numberDeclaration: numberDeclaration
+                                              ,objectDeclaration: objectDeclaration
+                                              ,listDeclaration: listDeclaration
+                                              ,stringStyle: stringStyle
+                                              ,numberStyle: numberStyle
+                                              ,objectStyle: objectStyle
+                                              ,listStyle: listStyle
+                                              ,StringStyle: StringStyle
+                                              ,NumberStyle: NumberStyle
+                                              ,ObjectStyle: ObjectStyle
+                                              ,ListStyle: ListStyle
+                                              ,encodeValue: encodeValue
+                                              ,encodeDeclaration: encodeDeclaration
+                                              ,encodeObject: encodeObject
+                                              ,toJsonProperty: toJsonProperty
+                                              ,encode: encode
+                                              ,color: color
+                                              ,fontFamily: fontFamily
+                                              ,fontSize: fontSize
+                                              ,fontStyle: fontStyle
+                                              ,fontWeight: fontWeight
+                                              ,letterSpacing: letterSpacing
+                                              ,lineHeight: lineHeight
+                                              ,textAlign: textAlign
+                                              ,textDecorationLine: textDecorationLine
+                                              ,textDecorationStyle: textDecorationStyle
+                                              ,textDecorationColor: textDecorationColor
+                                              ,writingDirection: writingDirection
+                                              ,backfaceVisibility: backfaceVisibility
+                                              ,backgroundColor: backgroundColor
+                                              ,borderColor: borderColor
+                                              ,borderTopColor: borderTopColor
+                                              ,borderRightColor: borderRightColor
+                                              ,borderBottomColor: borderBottomColor
+                                              ,borderLeftColor: borderLeftColor
+                                              ,borderRadius: borderRadius
+                                              ,borderTopLeftRadius: borderTopLeftRadius
+                                              ,borderTopRightRadius: borderTopRightRadius
+                                              ,borderBottomLeftRadius: borderBottomLeftRadius
+                                              ,borderBottomRightRadius: borderBottomRightRadius
+                                              ,borderStyle: borderStyle
+                                              ,borderWidth: borderWidth
+                                              ,borderTopWidth: borderTopWidth
+                                              ,borderRightWidth: borderRightWidth
+                                              ,borderBottomWidth: borderBottomWidth
+                                              ,borderLeftWidth: borderLeftWidth
+                                              ,opacity: opacity
+                                              ,overflow: overflow
+                                              ,shadowColor: shadowColor
+                                              ,shadowOffset: shadowOffset
+                                              ,shadowOpacity: shadowOpacity
+                                              ,shadowRadius: shadowRadius
+                                              ,resizeMode: resizeMode
+                                              ,tintColor: tintColor
+                                              ,alignItems: alignItems
+                                              ,alignSelf: alignSelf
+                                              ,bottom: bottom
+                                              ,flex: flex
+                                              ,flexDirection: flexDirection
+                                              ,flexWrap: flexWrap
+                                              ,height: height
+                                              ,justifyContent: justifyContent
+                                              ,left: left
+                                              ,margin: margin
+                                              ,marginBottom: marginBottom
+                                              ,marginHorizontal: marginHorizontal
+                                              ,marginLeft: marginLeft
+                                              ,marginRight: marginRight
+                                              ,marginTop: marginTop
+                                              ,marginVertical: marginVertical
+                                              ,padding: padding
+                                              ,paddingBottom: paddingBottom
+                                              ,paddingHorizontal: paddingHorizontal
+                                              ,paddingLeft: paddingLeft
+                                              ,paddingRight: paddingRight
+                                              ,paddingTop: paddingTop
+                                              ,paddingVertical: paddingVertical
+                                              ,position: position
+                                              ,right: right
+                                              ,top: top
+                                              ,width: width
+                                              ,Transform: Transform
+                                              ,defaultTransform: defaultTransform
+                                              ,transform: transform};
+    };
 function F2(fun)
 {
     function wrapper(a) { return function(b) { return fun(a,b); }; }
@@ -8736,165 +8896,250 @@ Elm.Native.ReactNative.make = function(localRuntime) {
 Elm.ReactNative = Elm.ReactNative || {};
 Elm.ReactNative.ReactNative = Elm.ReactNative.ReactNative || {};
 Elm.ReactNative.ReactNative.make = function (_elm) {
-   "use strict";
-   _elm.ReactNative = _elm.ReactNative || {};
-   _elm.ReactNative.ReactNative = _elm.ReactNative.ReactNative || {};
-   if (_elm.ReactNative.ReactNative.values) return _elm.ReactNative.ReactNative.values;
-   var _U = Elm.Native.Utils.make(_elm),
-   $Basics = Elm.Basics.make(_elm),
-   $Debug = Elm.Debug.make(_elm),
-   $Json$Decode = Elm.Json.Decode.make(_elm),
-   $Json$Encode = Elm.Json.Encode.make(_elm),
-   $List = Elm.List.make(_elm),
-   $Maybe = Elm.Maybe.make(_elm),
-   $Native$ReactNative = Elm.Native.ReactNative.make(_elm),
-   $ReactNative$Style = Elm.ReactNative.Style.make(_elm),
-   $Result = Elm.Result.make(_elm),
-   $Signal = Elm.Signal.make(_elm);
-   var _op = {};
-   var maybeEncodeHandler = function (handler) {
-      var _p0 = handler;
-      if (_p0.ctor === "Just") {
-            return A2($List._op["::"],{ctor: "_Tuple2",_0: _p0._0._0,_1: $Json$Encode.$int(_p0._0._1)},_U.list([]));
-         } else {
-            return _U.list([]);
-         }
-   };
-   var encode = function (vtree) {
-      var _p1 = vtree;
-      switch (_p1.ctor)
-      {case "VNode": return $Json$Encode.object(_U.list([{ctor: "_Tuple2",_0: "tagName",_1: $Json$Encode.string(_p1._0)}
-                                                        ,{ctor: "_Tuple2",_0: "style",_1: $ReactNative$Style.encode(_p1._1)}
-                                                        ,{ctor: "_Tuple2",_0: "children",_1: $Json$Encode.list(A2($List.map,encode,_p1._2))}]));
-         case "VText": return $Json$Encode.object(A2($Basics._op["++"],
-           maybeEncodeHandler(_p1._1),
-           _U.list([{ctor: "_Tuple2",_0: "tagName",_1: $Json$Encode.string("Text")}
-                   ,{ctor: "_Tuple2",_0: "style",_1: $ReactNative$Style.encode(_p1._0)}
-                   ,{ctor: "_Tuple2",_0: "children",_1: $Json$Encode.list(_U.list([$Json$Encode.string(_p1._2)]))}])));
-         default: return $Json$Encode.object(_U.list([{ctor: "_Tuple2",_0: "tagName",_1: $Json$Encode.string("Image")}
-                                                     ,{ctor: "_Tuple2",_0: "style",_1: $ReactNative$Style.encode(_p1._0)}
-                                                     ,{ctor: "_Tuple2",_0: "source",_1: $Json$Encode.string(_p1._1)}]));}
-   };
-   var on = F2(function (decoder,toMessage) {    return A2($Native$ReactNative.on,decoder,toMessage);});
-   var onPress = F2(function (address,msg) {
-      return {ctor: "_Tuple2",_0: "onPress",_1: A2(on,$Json$Decode.value,function (_p2) {    return A2($Signal.message,address,msg);})};
-   });
-   var VImage = F2(function (a,b) {    return {ctor: "VImage",_0: a,_1: b};});
-   var image = F2(function (styles,source) {    return A2(VImage,styles,source);});
-   var VText = F3(function (a,b,c) {    return {ctor: "VText",_0: a,_1: b,_2: c};});
-   var text = F3(function (styles,handler,textContent) {    return A3(VText,styles,handler,textContent);});
-   var VNode = F3(function (a,b,c) {    return {ctor: "VNode",_0: a,_1: b,_2: c};});
-   var node = F3(function (tagName,styles,children) {    return A3(VNode,tagName,styles,children);});
-   var view = F2(function (styles,children) {    return A3(VNode,"View",styles,children);});
-   return _elm.ReactNative.ReactNative.values = {_op: _op,node: node,view: view,text: text,image: image,encode: encode,onPress: onPress};
-};
+       "use strict";
+       _elm.ReactNative = _elm.ReactNative || {};
+       _elm.ReactNative.ReactNative = _elm.ReactNative.ReactNative ||
+           {};
+       if (_elm.ReactNative.ReactNative.values)
+          return _elm.ReactNative.ReactNative.values;
+       var _U = Elm.Native.Utils.make(_elm),
+       $Basics = Elm.Basics.make(_elm),
+       $Debug = Elm.Debug.make(_elm),
+       $Json$Decode = Elm.Json.Decode.make(_elm),
+       $Json$Encode = Elm.Json.Encode.make(_elm),
+       $List = Elm.List.make(_elm),
+       $Maybe = Elm.Maybe.make(_elm),
+       $Native$ReactNative = Elm.Native.ReactNative.make(_elm),
+       $ReactNative$Style = Elm.ReactNative.Style.make(_elm),
+       $Result = Elm.Result.make(_elm),
+       $Signal = Elm.Signal.make(_elm);
+       var _op = {};
+       var maybeEncodeHandler = function (handler) {
+          var _p0 = handler;
+          if (_p0.ctor === "Just") {
+             return A2($List._op["::"]
+                      ,{ctor: "_Tuple2"
+                       ,_0: _p0._0._0
+                       ,_1: $Json$Encode.$int(_p0._0._1)}
+                      ,_U.list([]));
+          } else {
+             return _U.list([]);
+          }
+       };
+       var encode = function (vtree) {
+          var _p1 = vtree;
+          switch (_p1.ctor)
+          {
+            case "VNode":
+              return $Json$Encode.object(_U.list([{ctor: "_Tuple2"
+                                                  ,_0: "tagName"
+                                                  ,_1: $Json$Encode.string(_p1._0)}
+                                                 ,{ctor: "_Tuple2"
+                                                  ,_0: "style"
+                                                  ,_1: $ReactNative$Style.encode(_p1._1)}
+                                                 ,{ctor: "_Tuple2"
+                                                  ,_0: "children"
+                                                  ,_1: $Json$Encode.list(A2($List.map,encode,_p1._2))}]));
+            case "VText":
+              return $Json$Encode.object(A2($Basics._op["++"]
+                                           ,maybeEncodeHandler(_p1._1)
+                                           ,_U.list([{ctor: "_Tuple2"
+                                                     ,_0: "tagName"
+                                                     ,_1: $Json$Encode.string("Text")}
+                                                    ,{ctor: "_Tuple2"
+                                                     ,_0: "style"
+                                                     ,_1: $ReactNative$Style.encode(_p1._0)}
+                                                    ,{ctor: "_Tuple2"
+                                                     ,_0: "children"
+                                                     ,_1: $Json$Encode.list(_U.list([$Json$Encode.string(_p1._2)]))}])));
+            default:
+              return $Json$Encode.object(_U.list([{ctor: "_Tuple2"
+                                                  ,_0: "tagName"
+                                                  ,_1: $Json$Encode.string("Image")}
+                                                 ,{ctor: "_Tuple2"
+                                                  ,_0: "style"
+                                                  ,_1: $ReactNative$Style.encode(_p1._0)}
+                                                 ,{ctor: "_Tuple2"
+                                                  ,_0: "source"
+                                                  ,_1: $Json$Encode.string(_p1._1)}]));
+          }
+       };
+       var on = F2(function (decoder,toMessage) {
+                   return A2($Native$ReactNative.on,decoder,toMessage);
+                });
+       var onPress = F2(function (address,msg) {
+                        return {ctor: "_Tuple2"
+                               ,_0: "onPress"
+                               ,_1: A2(on
+                                      ,$Json$Decode.value
+                                      ,function (_p2) {
+                                         return A2($Signal.message,address,msg);
+                                      })};
+                     });
+       var VImage = F2(function (a,b) {
+                       return {ctor: "VImage",_0: a,_1: b};
+                    });
+       var image = F2(function (styles,source) {
+                      return A2(VImage,styles,source);
+                   });
+       var VText = F3(function (a,b,c) {
+                      return {ctor: "VText",_0: a,_1: b,_2: c};
+                   });
+       var text = F3(function (styles,handler,textContent) {
+                     return A3(VText,styles,handler,textContent);
+                  });
+       var VNode = F3(function (a,b,c) {
+                      return {ctor: "VNode",_0: a,_1: b,_2: c};
+                   });
+       var node = F3(function (tagName,styles,children) {
+                     return A3(VNode,tagName,styles,children);
+                  });
+       var view = F2(function (styles,children) {
+                     return A3(VNode,"View",styles,children);
+                  });
+       return _elm.ReactNative.ReactNative.values = {_op: _op
+                                                    ,node: node
+                                                    ,view: view
+                                                    ,text: text
+                                                    ,image: image
+                                                    ,encode: encode
+                                                    ,onPress: onPress};
+    };
 Elm.ReactNative = Elm.ReactNative || {};
 Elm.ReactNative.NativeApp = Elm.ReactNative.NativeApp || {};
 Elm.ReactNative.NativeApp.make = function (_elm) {
-   "use strict";
-   _elm.ReactNative = _elm.ReactNative || {};
-   _elm.ReactNative.NativeApp = _elm.ReactNative.NativeApp || {};
-   if (_elm.ReactNative.NativeApp.values) return _elm.ReactNative.NativeApp.values;
-   var _U = Elm.Native.Utils.make(_elm),
-   $Basics = Elm.Basics.make(_elm),
-   $Debug = Elm.Debug.make(_elm),
-   $Json$Encode = Elm.Json.Encode.make(_elm),
-   $List = Elm.List.make(_elm),
-   $Maybe = Elm.Maybe.make(_elm),
-   $ReactNative$ReactNative = Elm.ReactNative.ReactNative.make(_elm),
-   $Result = Elm.Result.make(_elm),
-   $Signal = Elm.Signal.make(_elm);
-   var _op = {};
-   var Config = F4(function (a,b,c,d) {    return {model: a,view: b,update: c,init: d};});
-   var ConfigAction = function (a) {    return {ctor: "ConfigAction",_0: a};};
-   var Init = {ctor: "Init"};
-   var start = function (config) {
-      var normalUpdate = F2(function (maybeAction,model) {
-         var _p0 = maybeAction;
-         if (_p0.ctor === "Just") {
-               return A2(config.update,_p0._0,model);
-            } else {
-               return _U.crashCase("ReactNative.NativeApp",{start: {line: 41,column: 7},end: {line: 46,column: 52}},_p0)("This should never happen.");
-            }
-      });
-      var update = F2(function (action,model) {
-         var _p2 = action;
-         if (_p2.ctor === "ConfigAction") {
-               return A2(normalUpdate,_p2._0,model);
-            } else {
-               return model;
-            }
-      });
-      var actions = $Signal.mailbox($Maybe.Nothing);
-      var merged = $Signal.mergeMany(_U.list([A2($Signal.map,ConfigAction,actions.signal),A2($Signal.map,$Basics.always(Init),config.init)]));
-      var model = A3($Signal.foldp,update,config.model,merged);
-      var address = A2($Signal.forwardTo,actions.address,$Maybe.Just);
-      return A2($Signal.map,$ReactNative$ReactNative.encode,A2($Signal.map,config.view(address),model));
-   };
-   return _elm.ReactNative.NativeApp.values = {_op: _op,start: start};
-};
+       "use strict";
+       _elm.ReactNative = _elm.ReactNative || {};
+       _elm.ReactNative.NativeApp = _elm.ReactNative.NativeApp || {};
+       if (_elm.ReactNative.NativeApp.values)
+          return _elm.ReactNative.NativeApp.values;
+       var _U = Elm.Native.Utils.make(_elm),
+       $Basics = Elm.Basics.make(_elm),
+       $Debug = Elm.Debug.make(_elm),
+       $List = Elm.List.make(_elm),
+       $Maybe = Elm.Maybe.make(_elm),
+       $ReactNative$ReactNative =
+       Elm.ReactNative.ReactNative.make(_elm),
+       $Result = Elm.Result.make(_elm),
+       $Signal = Elm.Signal.make(_elm);
+       var _op = {};
+       var Config = F3(function (a,b,c) {
+                       return {model: a,view: b,update: c};
+                    });
+       var ConfigAction = function (a) {
+          return {ctor: "ConfigAction",_0: a};
+       };
+       var start = function (config) {
+          var normalUpdate = F2(function (maybeAction,model) {
+                                var _p0 = maybeAction;
+                                if (_p0.ctor === "Just") {
+                                   return A2(config.update,_p0._0,model);
+                                } else {
+                                   return _U.crashCase("ReactNative.NativeApp"
+                                                      ,{start: {line: 39,column: 7},end: {line: 44,column: 52}}
+                                                      ,_p0)("This should never happen.");
+                                }
+                             });
+          var update = F2(function (action,model) {
+                          var _p2 = action;
+                          if (_p2.ctor === "ConfigAction") {
+                             return A2(normalUpdate,_p2._0,model);
+                          } else {
+                             return model;
+                          }
+                       });
+          var actions = $Signal.mailbox($Maybe.Nothing);
+          var merged = $Signal.mergeMany(_U.list([A2($Signal.map
+                                                    ,ConfigAction
+                                                    ,actions.signal)]));
+          var model = A3($Signal.foldp,update,config.model,merged);
+          var address = A2($Signal.forwardTo,actions.address,$Maybe.Just);
+          return A2($Signal.map,config.view(address),model);
+       };
+       var Init = {ctor: "Init"};
+       return _elm.ReactNative.NativeApp.values = {_op: _op
+                                                  ,start: start};
+    };
 Elm.Main = Elm.Main || {};
 Elm.Main.make = function (_elm) {
-   "use strict";
-   _elm.Main = _elm.Main || {};
-   if (_elm.Main.values) return _elm.Main.values;
-   var _U = Elm.Native.Utils.make(_elm),
-   $Basics = Elm.Basics.make(_elm),
-   $Debug = Elm.Debug.make(_elm),
-   $Json$Encode = Elm.Json.Encode.make(_elm),
-   $List = Elm.List.make(_elm),
-   $Maybe = Elm.Maybe.make(_elm),
-   $ReactNative$NativeApp = Elm.ReactNative.NativeApp.make(_elm),
-   $ReactNative$ReactNative = Elm.ReactNative.ReactNative.make(_elm),
-   $ReactNative$Style = Elm.ReactNative.Style.make(_elm),
-   $Result = Elm.Result.make(_elm),
-   $Signal = Elm.Signal.make(_elm);
-   var _op = {};
-   var init = Elm.Native.Port.make(_elm).inboundSignal("init",
-   "()",
-   function (v) {
-      return typeof v === "object" && v instanceof Array ? {ctor: "_Tuple0"} : _U.badPort("an array",v);
-   });
-   var button = F4(function (address,action,color,content) {
-      return A3($ReactNative$ReactNative.text,
-      _U.list([$ReactNative$Style.color("white")
-              ,$ReactNative$Style.textAlign("center")
-              ,$ReactNative$Style.backgroundColor(color)
-              ,$ReactNative$Style.paddingTop(5)
-              ,$ReactNative$Style.paddingBottom(5)
-              ,$ReactNative$Style.width(30)
-              ,$ReactNative$Style.fontWeight("bold")
-              ,$ReactNative$Style.shadowColor("#000")
-              ,$ReactNative$Style.shadowOpacity(0.25)
-              ,A2($ReactNative$Style.shadowOffset,1,1)
-              ,$ReactNative$Style.shadowRadius(5)
-              ,$ReactNative$Style.transform(_U.update($ReactNative$Style.defaultTransform,{rotate: $Maybe.Just("10deg")}))]),
-      $Maybe.Just(A2($ReactNative$ReactNative.onPress,address,action)),
-      content);
-   });
-   var update = F2(function (action,model) {    var _p0 = action;if (_p0.ctor === "Increment") {    return model + 1;} else {    return model - 1;}});
-   var Decrement = {ctor: "Decrement"};
-   var Increment = {ctor: "Increment"};
-   var view = F2(function (address,count) {
-      return A2($ReactNative$ReactNative.view,
-      _U.list([$ReactNative$Style.alignItems("center")]),
-      _U.list([A2($ReactNative$ReactNative.image,
-              _U.list([$ReactNative$Style.height(64),$ReactNative$Style.width(64),$ReactNative$Style.marginBottom(30)]),
-              "https://raw.githubusercontent.com/futurice/spiceprogram/master/assets/img/logo/chilicorn_no_text-128.png")
-              ,A3($ReactNative$ReactNative.text,
-              _U.list([$ReactNative$Style.textAlign("center"),$ReactNative$Style.marginBottom(30)]),
-              $Maybe.Nothing,
-              A2($Basics._op["++"],"Counter: ",$Basics.toString(count)))
-              ,A2($ReactNative$ReactNative.view,
-              _U.list([$ReactNative$Style.width(80),$ReactNative$Style.flexDirection("row"),$ReactNative$Style.justifyContent("space-between")]),
-              _U.list([A4(button,address,Decrement,"#d33","-"),A4(button,address,Increment,"#3d3","+")]))]));
-   });
-   var model = 9000;
-   var viewTree = Elm.Native.Port.make(_elm).outboundSignal("viewTree",
-   function (v) {
-      return v;
-   },
-   $ReactNative$NativeApp.start({model: model,view: view,update: update,init: init}));
-   return _elm.Main.values = {_op: _op,model: model,view: view,Increment: Increment,Decrement: Decrement,update: update,button: button};
-};
+       "use strict";
+       _elm.Main = _elm.Main || {};
+       if (_elm.Main.values)    return _elm.Main.values;
+       var _U = Elm.Native.Utils.make(_elm),
+       $Basics = Elm.Basics.make(_elm),
+       $Debug = Elm.Debug.make(_elm),
+       $List = Elm.List.make(_elm),
+       $Maybe = Elm.Maybe.make(_elm),
+       $ReactNative$NativeApp = Elm.ReactNative.NativeApp.make(_elm),
+       $ReactNative$ReactNative =
+       Elm.ReactNative.ReactNative.make(_elm),
+       $ReactNative$Style = Elm.ReactNative.Style.make(_elm),
+       $Result = Elm.Result.make(_elm),
+       $Signal = Elm.Signal.make(_elm);
+       var _op = {};
+       var button = F4(function (address,action,color,content) {
+                       return A3($ReactNative$ReactNative.text
+                                ,_U.list([$ReactNative$Style.color("white")
+                                         ,$ReactNative$Style.textAlign("center")
+                                         ,$ReactNative$Style.backgroundColor(color)
+                                         ,$ReactNative$Style.paddingTop(5)
+                                         ,$ReactNative$Style.paddingBottom(5)
+                                         ,$ReactNative$Style.width(30)
+                                         ,$ReactNative$Style.fontWeight("bold")
+                                         ,$ReactNative$Style.shadowColor("#000")
+                                         ,$ReactNative$Style.shadowOpacity(0.25)
+                                         ,A2($ReactNative$Style.shadowOffset,1,1)
+                                         ,$ReactNative$Style.shadowRadius(5)
+                                         ,$ReactNative$Style.transform(_U.update($ReactNative$Style.defaultTransform
+                                                                                ,{rotate: $Maybe.Just("10deg")}))])
+                                ,$Maybe.Just(A2($ReactNative$ReactNative.onPress
+                                               ,address
+                                               ,action))
+                                ,content);
+                    });
+       var update = F2(function (action,model) {
+                       var _p0 = action;
+                       if (_p0.ctor === "Increment") {
+                          return model + 1;
+                       } else {
+                          return model - 1;
+                       }
+                    });
+       var Decrement = {ctor: "Decrement"};
+       var Increment = {ctor: "Increment"};
+       var view = F2(function (address,count) {
+                     return A2($ReactNative$ReactNative.view
+                              ,_U.list([$ReactNative$Style.alignItems("center")])
+                              ,_U.list([A2($ReactNative$ReactNative.image
+                                          ,_U.list([$ReactNative$Style.height(64)
+                                                   ,$ReactNative$Style.width(64)
+                                                   ,$ReactNative$Style.marginBottom(30)])
+                                          ,"https://raw.githubusercontent.com/futurice/spiceprogram/master/assets/img/logo/chilicorn_no_text-128.png")
+                                       ,A3($ReactNative$ReactNative.text
+                                          ,_U.list([$ReactNative$Style.textAlign("center")
+                                                   ,$ReactNative$Style.marginBottom(30)])
+                                          ,$Maybe.Nothing
+                                          ,A2($Basics._op["++"],"Counter: ",$Basics.toString(count)))
+                                       ,A2($ReactNative$ReactNative.view
+                                          ,_U.list([$ReactNative$Style.width(80)
+                                                   ,$ReactNative$Style.flexDirection("row")
+                                                   ,$ReactNative$Style.justifyContent("space-between")])
+                                          ,_U.list([A4(button,address,Decrement,"#d33","-")
+                                                   ,A4(button,address,Increment,"#3d3","+")]))]));
+                  });
+       var model = 9000;
+       var app = $ReactNative$NativeApp.start({model: model
+                                              ,view: view
+                                              ,update: update});
+       var main = app;
+       return _elm.Main.values = {_op: _op
+                                 ,app: app
+                                 ,main: main
+                                 ,model: model
+                                 ,view: view
+                                 ,Increment: Increment
+                                 ,Decrement: Decrement
+                                 ,update: update
+                                 ,button: button};
+    };
 module.exports = Elm;

--- a/index.android.js
+++ b/index.android.js
@@ -1,58 +1,9 @@
+/**
+ * Sample React Native App
+ * https://github.com/facebook/react-native
+ */
 'use strict';
-var React = require('react-native');
-var Elm = require('./elm');
-var {AppRegistry, StyleSheet, Text, View} = React;
+var {AppRegistry} = require('react-native');
+var ElmAppWrapper = require('./ElmAppWrapper');
 
-var program = Elm.worker(Elm.Main, { init: [] });
-
-function vtreeToReactElement(vtree) {
-  if (typeof vtree === 'string') {
-    return vtree;
-  }
-  if (vtree.tagName === 'Text') {
-    return React.createElement(Text, {
-      style: vtree.style,
-      onPress: vtree.onPress ?
-        program.ports._ReactNativeEventHandlers[vtree.onPress] :
-        undefined},
-      vtree.children
-    );
-  }
-  return React.createElement(
-    React[vtree.tagName],
-    { style: vtree.style },
-    vtree.children ? vtree.children.map(vtreeToReactElement) : []
-  );
-}
-
-function componentFactory() {
-  return React.createClass({
-    componentWillMount() {
-      program.ports.viewTree.subscribe(vtree => {
-        this.setState({vtree});
-        Elm.Native.ReactNative.prepareResetHandlers();
-      });
-      program.ports.init.send([]);
-    },
-    getInitialState() {
-      return {
-        vtree: {tagName: 'View', children: []},
-      };
-    },
-    render() {
-      return React.createElement(View, {style: styles.container},
-        vtreeToReactElement(this.state.vtree)
-      );
-    },
-  })
-}
-
-var styles = StyleSheet.create({
-  container: {
-    flex: 1,
-    justifyContent: 'center',
-    alignItems: 'center',
-  },
-});
-
-AppRegistry.registerComponent('ElmNative', componentFactory)
+AppRegistry.registerComponent('ElmNative', ElmAppWrapper);

--- a/index.ios.js
+++ b/index.ios.js
@@ -3,71 +3,7 @@
  * https://github.com/facebook/react-native
  */
 'use strict';
-var React = require('react-native');
-var Elm = require('./elm');
-var {
-  AppRegistry,
-  StyleSheet,
-  Text,
-  View,
-  Image,
-} = React;
+var {AppRegistry} = require('react-native');
+var ElmAppWrapper = require('./ElmAppWrapper');
 
-var program = Elm.worker(Elm.Main, { init: [] });
-
-function vtreeToReactElement(vtree) {
-  if (typeof vtree === 'string') {
-    return vtree;
-  }
-  if (vtree.tagName === 'Text') {
-    return React.createElement(Text, {
-      style: vtree.style,
-      onPress: vtree.onPress ?
-        program.ports._ReactNativeEventHandlers[vtree.onPress] :
-        undefined},
-      vtree.children
-    );
-  } else if (vtree.tagName === 'Image') {
-    return React.createElement(Image, {
-      style: vtree.style,
-      source: {uri: vtree.source},
-    });
-  }
-  return React.createElement(
-    React[vtree.tagName],
-    { style: vtree.style },
-    vtree.children ? vtree.children.map(vtreeToReactElement) : []
-  );
-}
-
-function componentFactory() {
-  return React.createClass({
-    componentWillMount() {
-      program.ports.viewTree.subscribe(vtree => {
-        this.setState({vtree});
-        Elm.Native.ReactNative.prepareResetHandlers();
-      });
-      program.ports.init.send([]);
-    },
-    getInitialState() {
-      return {
-        vtree: {tagName: 'View', children: []},
-      };
-    },
-    render() {
-      return React.createElement(View, {style: styles.container},
-        vtreeToReactElement(this.state.vtree)
-      );
-    },
-  })
-}
-
-var styles = StyleSheet.create({
-  container: {
-    flex: 1,
-    justifyContent: 'center',
-    alignItems: 'center',
-  },
-});
-
-AppRegistry.registerComponent('ElmNative', componentFactory)
+AppRegistry.registerComponent('ElmNative', ElmAppWrapper);


### PR DESCRIPTION
Hey, I figured it would make discussion / review easier if I make a separate PR, rather than continuing to comment on #24

To reacap: this depends on [this fork of the elm compiler](https://github.com/NoRedInk/elm-compiler/tree/elm-native-ui), which must be on your PATH before the standard elm compiler.  

You also need to replace the `elm-stuff/packages/elm-lang/core/3.0.0` directory with [this fork of elm-core](https://github.com/yusefnapora/core/tree/elm-native-ui), which adds an `Elm.embedReact` function to enable rendering for the `VTree` type.  Make sure you checkout the `elm-native-ui` branch when you clone it, btw.

I went ahead and converted the Native code to ES5 syntax, since it doesn't need any fancy ES6 goodies, and it's nice to have a consistent style.  However, it does still use `Object.assign`, so it's not completely free of ES6 runtime dependencies.  

I also tried to generally clean things up a bit and added some comments to `ReactNative.elm`

Let me know if there's anything else that needs doing :)
