### PR TITLE
Upgrade React to 0.22

### DIFF
--- a/examples/package.json
+++ b/examples/package.json
@@ -1,15 +1,16 @@
 {
-  "name": "ElmNativeUi",
+  "name": "MyAppName",
   "version": "0.0.1",
   "private": true,
   "scripts": {
     "precompile": "rm -f elm.js",
     "compile": "elm-make Main.elm --output elm.js",
     "postcompile": "echo 'module.exports = Elm;' >> elm.js",
-    "start": "chokidar '**/*.elm' -c 'npm run compile'"
+    "start": "node node_modules/react-native/local-cli/cli.js start",
+    "watch": "chokidar '**/*.elm' -c 'npm run compile'"
   },
   "dependencies": {
     "chokidar-cli": "^1.2.0",
-    "react-native": "0.21.0"
+    "react-native": "0.22.0"
   }
 }


### PR DESCRIPTION
In this PR I've upgraded react to the latest stable 0.22. I've also re-added the start task since react will prompt to execute `npm run start` in case it's not running so I think we shouldn't change it. The old `start` task is now called `watch`.
