### PR TITLE
Add navigation demo

### DIFF
--- a/examples/NavigationDemo/.gitignore
+++ b/examples/NavigationDemo/.gitignore
@@ -1,0 +1,41 @@
+# OSX
+#
+.DS_Store
+
+# Xcode
+#
+build/
+*.pbxuser
+!default.pbxuser
+*.mode1v3
+!default.mode1v3
+*.mode2v3
+!default.mode2v3
+*.perspectivev3
+!default.perspectivev3
+xcuserdata
+*.xccheckout
+*.moved-aside
+DerivedData
+*.hmap
+*.ipa
+*.xcuserstate
+project.xcworkspace
+
+# Android/IJ
+#
+*.iml
+.idea
+.gradle
+local.properties
+
+# node.js
+#
+node_modules/
+npm-debug.log
+
+# BUCK
+buck-out/
+\.buckd/
+android/app/libs
+android/keystores/debug.keystore

--- a/examples/NavigationDemo/elm-package.json
+++ b/examples/NavigationDemo/elm-package.json
@@ -1,0 +1,17 @@
+{
+    "version": "1.0.0",
+    "summary": "helpful summary of your project, less than 80 characters",
+    "repository": "https://github.com/elm-native-ui/elm-native-ui.git",
+    "license": "BSD3",
+    "source-directories": [
+        "./src",
+        "../../src"
+    ],
+    "exposed-modules": [],
+    "native-modules": true,
+    "dependencies": {
+        "elm-lang/core": "5.0.0 <= v < 6.0.0",
+        "elm-lang/html": "2.0.0 <= v < 3.0.0"
+    },
+    "elm-version": "0.18.0 <= v < 0.19.0"
+}

--- a/examples/NavigationDemo/index.android.js
+++ b/examples/NavigationDemo/index.android.js
@@ -1,0 +1,5 @@
+const { AppRegistry } = require('react-native');
+const Elm = require('./elm');
+const component = Elm.Main.start();
+
+AppRegistry.registerComponent('NavigationDemo', () => component);

--- a/examples/NavigationDemo/index.ios.js
+++ b/examples/NavigationDemo/index.ios.js
@@ -1,0 +1,5 @@
+const { AppRegistry } = require('react-native');
+const Elm = require('./elm');
+const component = Elm.Main.start();
+
+AppRegistry.registerComponent('NavigationDemo', () => component);

--- a/examples/NavigationDemo/package.json
+++ b/examples/NavigationDemo/package.json
@@ -1,0 +1,29 @@
+{
+  "name": "NavigationDemo",
+  "version": "0.0.1",
+  "private": true,
+  "scripts": {
+    "start": "node node_modules/react-native/local-cli/cli.js start",
+    "compile": "elm make ./src/Main.elm --output elm.js",
+    "build": "npm run compile --silent",
+    "test": "jest",
+    "watch-elm": "chokidar 'src/**/*.elm' -c 'npm run compile' --silent",
+    "watch-ios": "react-native run-ios",
+    "watch": "npm run compile && npm run watch-ios && npm run watch-elm"
+  },
+  "dependencies": {
+    "react": "15.3.2",
+    "react-native": "0.36.1"
+  },
+  "jest": {
+    "preset": "jest-react-native"
+  },
+  "devDependencies": {
+    "babel-jest": "16.0.0",
+    "babel-preset-react-native": "1.9.0",
+    "chokidar-cli": "^1.2.0",
+    "jest": "16.0.2",
+    "jest-react-native": "16.0.0",
+    "react-test-renderer": "15.3.2"
+  }
+}

--- a/examples/NavigationDemo/src/CardStack/Example.elm
+++ b/examples/NavigationDemo/src/CardStack/Example.elm
@@ -1,0 +1,93 @@
+module CardStack.Example exposing (Model, Msg(Start), init, update, view)
+
+import CardStack.NavigationMsg exposing (NavigationMsg(Exit, None, Pop, Push))
+import CardStack.Navigator as Navigator
+import NativeApi.NavigationStateUtil exposing (pop, push)
+import NativeUi exposing (Node, Property, node)
+import NativeUi.NavigationExperimental exposing (NavigationRoute, NavigationState, navigationState)
+
+
+-- MODEL
+
+
+type alias Model =
+    { navigator : Navigator.NavigatorModel
+    , counter : Int
+    }
+
+
+init : Bool -> Model
+init enableGestures =
+    { navigator =
+        { enableGestures = enableGestures
+        , navigationState =
+            { index = 0
+            , routes = [ { key = "Welcome", title = Nothing } ]
+            }
+        }
+    , counter = 1
+    }
+
+
+
+-- UPDATE
+
+
+type Msg
+    = Start Bool
+    | NavigationChange Navigator.NavigatorMsg
+
+
+update : Msg -> Model -> ( Model, Bool )
+update msg model =
+    case msg of
+        Start enableGestures ->
+            ( init enableGestures, False )
+
+        NavigationChange navigatorMsg ->
+            let
+                ( navigator, navigationMsg ) =
+                    Navigator.update navigatorMsg model.navigator
+            in
+                case navigationMsg of
+                    Exit ->
+                        ( model, True )
+
+                    None ->
+                        ( { model | navigator = navigator }, False )
+
+                    Pop ->
+                        let
+                            newNavigator =
+                                { navigator | navigationState = pop navigator.navigationState }
+                        in
+                            ( { model
+                                | navigator = newNavigator
+                                , counter = model.counter - 1
+                              }
+                            , False
+                            )
+
+                    Push ->
+                        let
+                            route =
+                                { key = "route - " ++ toString model.counter, title = Nothing }
+
+                            newNavigator =
+                                { navigator | navigationState = push route navigator.navigationState }
+                        in
+                            ( { model
+                                | navigator = newNavigator
+                                , counter = model.counter + 1
+                              }
+                            , False
+                            )
+
+
+
+-- VIEW
+
+
+view : Model -> Node Msg
+view model =
+    Navigator.view model.navigator |> NativeUi.map NavigationChange

--- a/examples/NavigationDemo/src/CardStack/NavigationMsg.elm
+++ b/examples/NavigationDemo/src/CardStack/NavigationMsg.elm
@@ -1,0 +1,8 @@
+module CardStack.NavigationMsg exposing (NavigationMsg(Exit, None, Pop, Push))
+
+
+type NavigationMsg
+    = Exit
+    | None
+    | Pop
+    | Push

--- a/examples/NavigationDemo/src/CardStack/Navigator.elm
+++ b/examples/NavigationDemo/src/CardStack/Navigator.elm
@@ -1,0 +1,53 @@
+module CardStack.Navigator exposing (NavigatorModel, NavigatorMsg, update, view)
+
+import CardStack.NavigationMsg exposing (NavigationMsg(Exit, None, Pop, Push))
+import CardStack.Scene as Scene
+import NativeUi as Ui exposing (Node, node, map)
+import NativeUi.Elements as Elements
+import NativeUi.Events as Events
+import NativeUi.NavigationExperimental as NE
+import NativeUi.Properties exposing (enableGestures)
+import NativeUi.Style as Style
+
+
+type alias NavigatorModel =
+    { enableGestures : Bool
+    , navigationState : NE.NavigationState
+    }
+
+
+type NavigatorMsg
+    = Back
+    | Scene NavigationMsg
+
+
+update : NavigatorMsg -> NavigatorModel -> ( NavigatorModel, NavigationMsg )
+update msg model =
+    case msg of
+        Back ->
+            ( model, Pop )
+
+        Scene navigationMsg ->
+            ( model, navigationMsg )
+
+
+
+-- VIEW
+
+
+view : NavigatorModel -> Node NavigatorMsg
+view model =
+    Elements.navigationCardStack
+        [ Ui.style
+            [ Style.flex 1 ]
+        , NE.navigationState model.navigationState
+        , Events.onNavigateBack Back
+        , NE.renderScene viewScene
+        , enableGestures model.enableGestures
+        ]
+        []
+
+
+viewScene : NE.NavigationSceneRenderer -> Node NavigatorMsg
+viewScene props =
+    Scene.view props |> Ui.map Scene

--- a/examples/NavigationDemo/src/CardStack/Scene.elm
+++ b/examples/NavigationDemo/src/CardStack/Scene.elm
@@ -1,0 +1,18 @@
+module CardStack.Scene exposing (view)
+
+import CardStack.NavigationMsg exposing (NavigationMsg(Exit, None, Pop, Push))
+import ExampleRow as Row
+import NativeUi exposing (Node)
+import NativeUi.Elements as Elements
+import NativeUi.NavigationExperimental exposing (NavigationSceneRenderer)
+
+
+view : NavigationSceneRenderer -> Node NavigationMsg
+view props =
+    Elements.scrollView
+        []
+        [ Row.label props.scene.route.key
+        , Row.button "Push Route" Push
+        , Row.button "Pop Route" Pop
+        , Row.button "Exit Card Stack Example" Exit
+        ]

--- a/examples/NavigationDemo/src/ExampleRow.elm
+++ b/examples/NavigationDemo/src/ExampleRow.elm
@@ -1,0 +1,52 @@
+module ExampleRow exposing (button, label, underlayColor)
+
+import Json.Encode
+import NativeUi as Ui exposing (Node, Property, property, string, style)
+import NativeUi.Elements exposing (touchableHighlight, text, view)
+import NativeUi.Events as Events exposing (onPress)
+import NativeUi.Style as Style
+
+
+label : String -> Node msg
+label label =
+    view [ Ui.style styleRow ]
+        [ text
+            [ Ui.style
+                [ Style.fontSize 17 ]
+            ]
+            [ Ui.string label ]
+        ]
+
+
+button : String -> msg -> Node msg
+button label onPressMsg =
+    touchableHighlight
+        [ style styleRow
+        , underlayColor "#D0D0D0"
+        , Events.onPress onPressMsg
+        ]
+        [ text
+            [ Ui.style
+                [ Style.fontSize 17
+                , Style.fontWeight "500"
+                ]
+            ]
+            [ Ui.string label ]
+        ]
+
+
+styleRow : List Style.Style
+styleRow =
+    [ Style.padding 15
+    , Style.backgroundColor "white"
+    , Style.borderBottomWidth 1
+    , Style.borderBottomColor "#CDCDCD"
+    ]
+
+
+{-|
+Custom property definition - for when items are missing from elm-native-ui
+-}
+underlayColor : String -> Property msg
+underlayColor val =
+    property "underlayColor" (Json.Encode.string val)

--- a/examples/NavigationDemo/src/Main.elm
+++ b/examples/NavigationDemo/src/Main.elm
@@ -1,0 +1,153 @@
+module Main exposing (..)
+
+{-|
+ Elm implementation of the NavigationExperimental example from the react-native UIExplorer example:
+https://github.com/facebook/react-native/tree/master/Examples/UIExplorer/js/NavigationExperimental
+-}
+
+import CardStack.Example as CS
+import ExampleRow exposing (underlayColor)
+import NativeUi as Ui exposing (Node)
+import NativeUi.Elements as Elements exposing (scrollView, text, touchableHighlight, view)
+import NativeUi.Events exposing (onPress)
+import NativeUi.Properties as Properties
+import NativeUi.Style as Style
+
+
+-- PROGRAM
+
+
+main : Program Never Model Msg
+main =
+    Ui.program
+        { init = init
+        , view = view
+        , update = update
+        , subscriptions = \_ -> Sub.none
+        }
+
+
+
+-- MODEL
+
+
+type alias Model =
+    { current : Current
+    , cardStack : CS.Model
+    , cardStackNoGesture : CS.Model
+    }
+
+
+init : ( Model, Cmd Msg )
+init =
+    ( { current = None
+      , cardStack = CS.init True
+      , cardStackNoGesture = CS.init False
+      }
+    , Cmd.none
+    )
+
+
+
+-- UPDATE
+
+
+type Msg
+    = CardStack CS.Msg
+
+
+
+type Current
+    = None
+    | ExampleCardStack
+
+
+update : Msg -> Model -> ( Model, Cmd Msg )
+update msg model =
+    case msg of
+        CardStack cardStackMsg ->
+            let
+                ( current, cardStack ) =
+                    updateSubModel cardStackMsg model.cardStack CS.update ExampleCardStack
+            in
+                ( { model | current = current, cardStack = cardStack }, Cmd.none )
+
+
+updateSubModel : msg -> model -> (msg -> model -> ( model, Bool )) -> Current -> ( Current, model )
+updateSubModel subMsg subModel updateFunc current =
+    let
+        ( newSubModel, exit ) =
+            updateFunc subMsg subModel
+    in
+        if exit then
+            ( None, newSubModel )
+        else
+            ( current, newSubModel )
+
+
+
+-- VIEW
+
+
+view : Model -> Node Msg
+view model =
+    case model.current of
+        None ->
+            viewNone
+
+        ExampleCardStack ->
+            viewCardStack model.cardStack
+
+
+viewNone : Node Msg
+viewNone =
+    Elements.scrollView
+        []
+        [ label "Navigation Experimental"
+        , row "CardStack Example" <| CardStack <| CS.Start True
+        ]
+
+
+viewCardStack : CS.Model -> Node Msg
+viewCardStack model =
+    CS.view model |> Ui.map CardStack
+
+
+label : String -> Node a
+label label =
+    Elements.view [ Ui.style styleRow ]
+        [ Elements.text
+            [ Ui.style
+                [ Style.fontSize 20
+                , Style.textAlign "center"
+                ]
+            , Properties.numberOfLines 1.0
+            ]
+            [ Ui.string label ]
+        ]
+
+
+row : String -> msg -> Node msg
+row label message =
+    Elements.touchableHighlight
+        [ Ui.style styleRow
+        , underlayColor "#D0D0D0"
+        , onPress message
+        ]
+        [ Elements.text
+            [ Ui.style
+                [ Style.fontSize 17
+                , Style.fontWeight "500"
+                ]
+            ]
+            [ Ui.string label ]
+        ]
+
+
+styleRow : List Style.Style
+styleRow =
+    [ Style.padding 15
+    , Style.backgroundColor "white"
+    , Style.borderBottomWidth 1
+    , Style.borderBottomColor "#CDCDCD"
+    ]

--- a/generator/elm-transformer.js
+++ b/generator/elm-transformer.js
@@ -13,6 +13,7 @@ class ElmTransformer {
     this.funcPropertyTemplate = fs.readFileSync("templates/func-property.ejs", 'utf8');
     this.funcConstantPropertyTemplate = fs.readFileSync("templates/func-constant-property.ejs", 'utf8');
     this.elementTemplate = fs.readFileSync("templates/element.ejs", 'utf8');
+    this.elementCustomTemplate = fs.readFileSync("templates/element-custom.ejs", 'utf8');
     this.uriPropertyTemplate = fs.readFileSync("templates/uri-property.ejs", 'utf8');
   }
 
@@ -23,6 +24,11 @@ class ElmTransformer {
 
   element(elementName, elementFuncName) {
     return ejs.render(this.elementTemplate, { elementName: elementName, elementFuncName: elementFuncName });
+  }
+
+  elementCustom(elementName, elementFuncName, moduleName, exportedName) {
+    return ejs.render(this.elementCustomTemplate, { elementName: elementName, elementFuncName: elementFuncName,
+      moduleName: moduleName, exportedName: exportedName });
   }
 
   property(propName, propType) {
@@ -61,13 +67,13 @@ class ElmTransformer {
 
       return ejs.render(this.funcPropertyTemplate, {
         funcName: funcName,
-        handlerName: funcName.replace("on", ""),
+        handlerName: funcName.replace(/^on/, ""),
         decoder: decoder
       });
     } else {
       return ejs.render(this.funcConstantPropertyTemplate, {
         funcName: funcName,
-        handlerName: funcName.replace("on", "")
+        handlerName: funcName.replace(/^on/, "")
       });
     }
 

--- a/generator/templates/element-custom.ejs
+++ b/generator/templates/element-custom.ejs
@@ -1,0 +1,4 @@
+{-| -}
+<%- elementFuncName %> : List (Property msg) -> List (Node msg) -> Node msg
+<%- elementFuncName %> =
+    customNode "<%- elementName %>" "<%- moduleName %>" <%- exportedName %>

--- a/generator/templates/elements-module.ejs
+++ b/generator/templates/elements-module.ejs
@@ -5,7 +5,7 @@ module NativeUi.Elements exposing (<%- moduleExports %>)
 @docs <%- moduleExports %>
 -}
 
-import NativeUi exposing (Property, Node, node)
+import NativeUi exposing (Property, Node, customNode, node)
 
 
 <%- content %>

--- a/generator/templates/properties-module.ejs
+++ b/generator/templates/properties-module.ejs
@@ -1,4 +1,4 @@
-module NativeUi.Properties exposing (<%- moduleExports %>)
+module NativeUi.Properties exposing (key, <%- moduleExports %>)
 
 {-| elm-native-ui Properties
 
@@ -7,5 +7,12 @@ module NativeUi.Properties exposing (<%- moduleExports %>)
 
 import Json.Encode
 import NativeUi exposing (Property, property)
+
+
+{-| -}
+key : String -> Property msg
+key val =
+    property "key" (Json.Encode.string val)
+
 
 <%- content %>

--- a/generator/templates/uri-property.ejs
+++ b/generator/templates/uri-property.ejs
@@ -2,4 +2,3 @@
 <%- propName %> : String -> Property msg
 <%- propName %> uri =
     property "<%- propName %>" (Json.Encode.object [ ( "uri", Json.Encode.string uri ) ])
-

--- a/src/NativeApi/Animated.elm
+++ b/src/NativeApi/Animated.elm
@@ -1,0 +1,22 @@
+module NativeApi.Animated exposing (AnimatedValue, decodeAnimatedValue, encodeAnimatedValue)
+
+import Json.Decode as Decode
+import Json.Encode as Encode
+
+
+-- ANIMATED VALUE
+
+
+type alias AnimatedValue =
+    Decode.Value
+
+
+encodeAnimatedValue : AnimatedValue -> Encode.Value
+encodeAnimatedValue =
+    identity
+
+
+decodeAnimatedValue : Decode.Decoder AnimatedValue
+decodeAnimatedValue =
+    Decode.value
+

--- a/src/NativeApi/NavigationStateUtil.elm
+++ b/src/NativeApi/NavigationStateUtil.elm
@@ -1,0 +1,167 @@
+module NativeApi.NavigationStateUtil exposing (back, get, getRoute, forward, has, indexOf, jumpTo, jumpToIndex, pop, push, replaceAt, replaceAtIndex, reset)
+
+{-|
+ Elm implementation of the NavigationExperimental example from the react-native UIExplorer example:
+https://github.com/facebook/react-native/blob/master/Libraries/NavigationExperimental/NavigationStateUtils.js
+-}
+
+import Array as Array
+import NativeUi.NavigationExperimental exposing (NavigationRoute, NavigationScene, NavigationState)
+import Tuple exposing (first, second)
+
+
+getRoute : Int -> NavigationState -> Maybe NavigationRoute
+getRoute index state =
+    List.indexedMap (\i r -> ( i, r )) state.routes
+        |> List.filter (\( i, r ) -> i == index)
+        |> List.head
+        |> Maybe.map second
+
+
+get : String -> NavigationState -> Maybe NavigationRoute
+get key state =
+    List.filter (\r -> r.key == key) state.routes
+        |> List.head
+
+
+indexOf : String -> NavigationState -> Maybe Int
+indexOf key state =
+    List.indexedMap (\i r -> ( i, r )) state.routes
+        |> List.filter (\( i, r ) -> r.key == key)
+        |> List.head
+        |> Maybe.map first
+
+
+has : NavigationRoute -> NavigationState -> Bool
+has route state =
+    List.filter (\x -> x.key == route.key) state.routes
+        |> List.isEmpty
+        |> not
+
+
+pop : NavigationState -> NavigationState
+pop state =
+    case List.reverse state.routes of
+        [] ->
+            state
+
+        [ x ] ->
+            state
+
+        x :: xs ->
+            let
+                routes =
+                    List.reverse xs
+            in
+                { state
+                    | index = (List.length routes) - 1
+                    , routes = routes
+                }
+
+
+push : NavigationRoute -> NavigationState -> NavigationState
+push route state =
+    let
+        exists =
+            List.any (\x -> x.key == route.key) state.routes
+    in
+        if exists then
+            Debug.crash <| "should not push route with duplicated key " ++ route.key
+        else
+            let
+                routes =
+                    List.append state.routes [ route ]
+            in
+                { state
+                    | index = (List.length routes) - 1
+                    , routes = routes
+                }
+
+
+jumpToIndex : Int -> NavigationState -> NavigationState
+jumpToIndex index state =
+    if index == state.index then
+        state
+    else if index + 1 > (List.length state.routes) then
+        Debug.crash <| "invalid index " ++ (toString index) ++ " to jump to"
+    else
+        { state | index = index }
+
+
+jumpTo : String -> NavigationState -> NavigationState
+jumpTo key state =
+    case indexOf key state of
+        Nothing ->
+            Debug.crash <| "invalid key '" ++ key ++ "' to jump to"
+
+        Just index ->
+            jumpToIndex index state
+
+
+back : NavigationState -> NavigationState
+back state =
+    case getRoute (state.index - 1) state of
+        Nothing ->
+            state
+
+        Just route ->
+            jumpToIndex (state.index - 1) state
+
+
+forward : NavigationState -> NavigationState
+forward state =
+    case getRoute (state.index + 1) state of
+        Nothing ->
+            state
+
+        Just route ->
+            jumpToIndex (state.index + 1) state
+
+
+replaceAt : String -> NavigationRoute -> NavigationState -> NavigationState
+replaceAt key route state =
+    case indexOf key state of
+        Nothing ->
+            Debug.crash <| "invalid key '" ++ key ++ "' for replacing route " ++ route.key
+
+        Just index ->
+            replaceAtIndex index route state
+
+
+replaceAtIndex : Int -> NavigationRoute -> NavigationState -> NavigationState
+replaceAtIndex index route state =
+    let
+        maybeOriginal =
+            getRoute index state
+    in
+        case maybeOriginal of
+            Nothing ->
+                Debug.crash <| "invalid index " ++ (toString index) ++ " for replacing route " ++ route.key
+
+            Just original ->
+                if original == route then
+                    { state | index = index }
+                else
+                    { state | index = index, routes = List.map (substitute original route) state.routes }
+
+
+substitute : NavigationRoute -> NavigationRoute -> NavigationRoute -> NavigationRoute
+substitute old new value =
+    if old.key == value.key then
+        new
+    else
+        value
+
+
+reset : Maybe Int -> List NavigationRoute -> NavigationState
+reset maybeIndex routes =
+    let
+        maxIndex =
+            (List.length routes) - 1
+
+        index =
+            Maybe.withDefault maxIndex maybeIndex
+    in
+        { index = index
+        , routes = routes
+        }

--- a/src/NativeUi.elm
+++ b/src/NativeUi.elm
@@ -1,9 +1,9 @@
-module NativeUi exposing (Node, node, string, style, on, Property, property, map, program)
+module NativeUi exposing (Node, customNode, node, string, style, on, Property, property, map, program, renderProperty)
 
 {-| Render your application as a React Native app.
 
 # Common Helpers
-@docs node, string, style, property, map
+@docs node, string, customNode, style, property, map, renderProperty
 
 # Events
 @docs on
@@ -37,6 +37,12 @@ node =
 
 
 {-| -}
+customNode : String -> String -> Maybe String -> List (Property msg) -> List (Node msg) -> Node msg
+customNode =
+    Native.NativeUi.customNode
+
+
+{-| -}
 string : String -> Node msg
 string =
     Native.NativeUi.string
@@ -44,11 +50,16 @@ string =
 
 {-| -}
 property : String -> Value -> Property msg
-property name value =
+property =
     Native.NativeUi.property
 
 
 {-| -}
+renderProperty : String -> Decoder a -> (a -> Node b) -> Property msg
+renderProperty =
+    Native.NativeUi.renderProperty
+
+
 style : List Style.Style -> Property msg
 style styles =
     Style.encode styles

--- a/src/NativeUi/Elements.elm
+++ b/src/NativeUi/Elements.elm
@@ -1,11 +1,11 @@
-module NativeUi.Elements exposing (text, image, activityIndicator, mapView, picker, progressBar, progressView, refreshControl, scrollView, segmentedControl, slider, statusBar, switch, tabBar, textInput, toolbar, view)
+module NativeUi.Elements exposing (text, image, activityIndicator, mapView, picker, progressBar, progressView, refreshControl, scrollView, segmentedControl, slider, statusBar, switch, tabBar, textInput, toolbar, touchableHighlight, view, navigationCardStack)
 
 {-| elm-native-ui Elements
 
-@docs text, image, activityIndicator, mapView, picker, progressBar, progressView, refreshControl, scrollView, segmentedControl, slider, statusBar, switch, tabBar, textInput, toolbar, view
+@docs text, image, activityIndicator, mapView, picker, progressBar, progressView, refreshControl, scrollView, segmentedControl, slider, statusBar, switch, tabBar, textInput, toolbar, touchableHighlight, view, navigationCardStack
 -}
 
-import NativeUi exposing (Property, Node, node)
+import NativeUi exposing (Property, Node, customNode, node)
 
 
 {-| -}
@@ -105,6 +105,18 @@ toolbar =
 
 
 {-| -}
+touchableHighlight : List (Property msg) -> List (Node msg) -> Node msg
+touchableHighlight =
+    node "TouchableHighlight"
+
+
+{-| -}
 view : List (Property msg) -> List (Node msg) -> Node msg
 view =
     node "View"
+
+
+{-| -}
+navigationCardStack : List (Property msg) -> List (Node msg) -> Node msg
+navigationCardStack =
+    customNode "NavigationCardStack" "NavigationCardStack" Nothing

--- a/src/NativeUi/Events.elm
+++ b/src/NativeUi/Events.elm
@@ -1,8 +1,8 @@
-module NativeUi.Events exposing (onLayout, onPress, onLongPress, onRegionChange, onRegionChangeComplete, onAnnotationPress, onPickerValueChange, onRefresh, onScroll, onScrollAnimationEnd, onContentSizeChange)
+module NativeUi.Events exposing (onLayout, onPress, onLongPress, onRegionChange, onRegionChangeComplete, onAnnotationPress, onPickerValueChange, onRefresh, onScroll, onScrollAnimationEnd, onContentSizeChange, onShowUnderlay, onHideUnderlay, onNavigateBack)
 
 {-| elm-native-ui Handlers
 
-@docs onLayout, onPress, onLongPress, onRegionChange, onRegionChangeComplete, onAnnotationPress, onPickerValueChange, onRefresh, onScroll, onScrollAnimationEnd, onContentSizeChange
+@docs onLayout, onPress, onLongPress, onRegionChange, onRegionChangeComplete, onAnnotationPress, onPickerValueChange, onRefresh, onScroll, onScrollAnimationEnd, onContentSizeChange, onShowUnderlay, onHideUnderlay, onNavigateBack
 -}
 
 import Json.Decode as Decode exposing (Value, Decoder)
@@ -78,3 +78,21 @@ onScrollAnimationEnd =
 onContentSizeChange : msg -> Property msg
 onContentSizeChange =
     constantMsgEvent "ContentSizeChange"
+
+
+{-| -}
+onShowUnderlay : msg -> Property msg
+onShowUnderlay =
+    constantMsgEvent "ShowUnderlay"
+
+
+{-| -}
+onHideUnderlay : msg -> Property msg
+onHideUnderlay =
+    constantMsgEvent "HideUnderlay"
+
+
+{-| -}
+onNavigateBack : msg -> Property msg
+onNavigateBack =
+    constantMsgEvent "NavigateBack"

--- a/src/NativeUi/NavigationExperimental.elm
+++ b/src/NativeUi/NavigationExperimental.elm
@@ -1,0 +1,209 @@
+module NativeUi.NavigationExperimental exposing (NavigationSceneRenderer, NavigationRoute, NavigationScene, NavigationState, layout, navigationState, renderScene, scene, navigationSceneRendererToPropertyList)
+
+import Json.Decode as Decode
+import Json.Encode as Encode exposing (Value, bool, int, list, object, string)
+import Native.NativeUi
+import NativeApi.Animated exposing (AnimatedValue, decodeAnimatedValue, encodeAnimatedValue)
+import NativeUi exposing (Node, Property, on, property, renderProperty)
+import NativeUi.Style as Style
+
+
+-- RENDER
+
+renderScene : (NavigationSceneRenderer -> Node a) -> Property msg
+renderScene =
+    renderProperty "renderScene" decodeNavigationSceneRenderer
+
+
+-- NAVIGATION LAYOUT
+
+
+type alias NavigationLayout =
+    { height : AnimatedValue
+    , initHeight : Float
+    , initWidth : Float
+    , isMeasured : Bool
+    , width : AnimatedValue
+    }
+
+
+layout : NavigationLayout -> Property msg
+layout val =
+    property "layout" (encodeNavigationLayout val)
+
+
+encodeNavigationLayout : NavigationLayout -> Value
+encodeNavigationLayout layout =
+    Encode.object <|
+        [ ( "height", encodeAnimatedValue layout.height )
+        , ( "initHeight", Encode.float layout.initHeight )
+        , ( "initWidth", Encode.float layout.initWidth )
+        , ( "isMeasured", Encode.bool layout.isMeasured )
+        , ( "width", encodeAnimatedValue layout.width )
+        ]
+
+
+decodeLayout : Decode.Decoder NavigationLayout
+decodeLayout =
+    Decode.map5 NavigationLayout
+        (Decode.field "height" decodeAnimatedValue)
+        (Decode.field "initHeight" Decode.float)
+        (Decode.field "initWidth" Decode.float)
+        (Decode.field "isMeasured" Decode.bool)
+        (Decode.field "width" decodeAnimatedValue)
+
+
+
+-- NAVIGATION ROUTE
+
+
+type alias NavigationRoute =
+    { key : String
+    , title : Maybe String
+    }
+
+
+encodeRoute : NavigationRoute -> Value
+encodeRoute route =
+    Encode.object <|
+        [ ( "key", Encode.string route.key )
+        , ( "title", Maybe.map Encode.string route.title |> Maybe.withDefault Encode.null )
+        ]
+
+
+decodeRoute : Decode.Decoder NavigationRoute
+decodeRoute =
+    Decode.map2 NavigationRoute
+        (Decode.field "key" Decode.string)
+        (Decode.maybe (Decode.field "title" Decode.string))
+
+
+
+-- NAVIGATION SCENE
+
+
+type alias NavigationScene =
+    { index : Int
+    , isActive : Bool
+    , isStale : Bool
+    , key : String
+    , route : NavigationRoute
+    }
+
+
+scene : NavigationScene -> Property msg
+scene val =
+    property "scene" (encodeNavigationScene val)
+
+
+encodeNavigationScene : NavigationScene -> Value
+encodeNavigationScene scene =
+    Encode.object <|
+        [ ( "index", Encode.int scene.index )
+        , ( "isActive", Encode.bool scene.isActive )
+        , ( "isStale", Encode.bool scene.isStale )
+        , ( "key", Encode.string scene.key )
+        , ( "route", encodeRoute scene.route )
+        ]
+
+
+decodeNavigationScene : Decode.Decoder NavigationScene
+decodeNavigationScene =
+    Decode.map5 NavigationScene
+        (Decode.field "index" Decode.int)
+        (Decode.field "isActive" Decode.bool)
+        (Decode.field "isStale" Decode.bool)
+        (Decode.field "key" Decode.string)
+        (Decode.field "route" decodeRoute)
+
+
+
+-- NAVIGATION STATE
+
+
+type alias NavigationState =
+    { index : Int
+    , routes : List NavigationRoute
+    }
+
+
+navigationState : NavigationState -> Property msg
+navigationState val =
+    property "navigationState" (encodeNavigationState val)
+
+
+encodeNavigationState : NavigationState -> Value
+encodeNavigationState state =
+    Encode.object <|
+        [ ( "index", Encode.int state.index )
+        , ( "routes", Encode.list <| List.map encodeRoute state.routes )
+        ]
+
+
+decodeNavigationState : Decode.Decoder NavigationState
+decodeNavigationState =
+    Decode.map2 NavigationState
+        (Decode.field "index" Decode.int)
+        (Decode.field "routes" (Decode.list decodeRoute))
+
+
+-- NAVIGATION SCENE RENDERER PROPS
+
+
+type alias NavigationSceneRenderer =
+    { layout : NavigationLayout
+    , navigationState : NavigationState
+    , position : AnimatedValue
+    , progress : AnimatedValue
+    , scene : NavigationScene
+    , scenes : List NavigationScene
+    }
+
+
+encodeNavigationSceneRenderer : NavigationSceneRenderer -> Value
+encodeNavigationSceneRenderer props =
+    Encode.object <|
+        [ ( "layout", encodeNavigationLayout props.layout )
+        , ( "navigationState", encodeNavigationState props.navigationState )
+        , ( "position", encodeAnimatedValue props.position )
+        , ( "progress", encodeAnimatedValue props.progress )
+        , ( "scene", encodeNavigationScene props.scene )
+        , ( "scenes", Encode.list <| List.map encodeNavigationScene props.scenes )
+        ]
+
+
+decodeNavigationSceneRenderer : Decode.Decoder NavigationSceneRenderer
+decodeNavigationSceneRenderer =
+    Decode.map6 NavigationSceneRenderer
+        (Decode.field "layout" decodeLayout)
+        (Decode.field "navigationState" decodeNavigationState)
+        (Decode.field "position" decodeAnimatedValue)
+        (Decode.field "progress" decodeAnimatedValue)
+        (Decode.field "scene" decodeNavigationScene)
+        (Decode.field "scenes" (Decode.list decodeNavigationScene))
+
+
+position : AnimatedValue -> Property msg
+position val =
+    property "position" (encodeAnimatedValue val)
+
+
+progress : AnimatedValue -> Property msg
+progress val =
+    property "progress" (encodeAnimatedValue val)
+
+
+scenes : List NavigationScene -> Property msg
+scenes val =
+    property "scenes" (Encode.list <| List.map encodeNavigationScene val)
+
+
+navigationSceneRendererToPropertyList : NavigationSceneRenderer -> List (Property msg)
+navigationSceneRendererToPropertyList props =
+    [ layout props.layout
+    , navigationState props.navigationState
+    , position props.position
+    , progress props.progress
+    , scene props.scene
+    , scenes props.scenes
+    ]

--- a/src/NativeUi/Properties.elm
+++ b/src/NativeUi/Properties.elm
@@ -1,12 +1,19 @@
-module NativeUi.Properties exposing (ellipsizeMode, numberOfLines, selectable, suppressHighlighting, testID, allowFontScaling, accessible, adjustsFontSizeToFit, minimumFontScale, source, defaultSource, showsUserLocation, followUserLocation, showsPointsOfInterest, showsCompass, zoomEnabled, rotateEnabled, pitchEnabled, scrollEnabled, mapType, maxDelta, minDelta, active, enabled, mode, prompt, refreshing, title, progressViewOffset, automaticallyAdjustContentInsets, bounces, bouncesZoom, alwaysBounceHorizontal, alwaysBounceVertical, centerContent, horizontal, indicatorStyle, directionalLockEnabled, canCancelContentTouches, keyboardDismissMode, keyboardShouldPersistTaps, maximumZoomScale, minimumZoomScale, pagingEnabled, scrollEventThrottle, scrollsToTop, showsHorizontalScrollIndicator, showsVerticalScrollIndicator, snapToInterval, snapToAlignment, removeClippedSubviews, zoomScale, scrollPerfTag, hidden, animated, translucent, barStyle, networkActivityIndicatorVisible, showHideTransition, itemPositioning)
+module NativeUi.Properties exposing (key, ellipsizeMode, numberOfLines, selectable, suppressHighlighting, testID, allowFontScaling, accessible, adjustsFontSizeToFit, minimumFontScale, source, defaultSource, showsUserLocation, followUserLocation, showsPointsOfInterest, showsCompass, zoomEnabled, rotateEnabled, pitchEnabled, scrollEnabled, mapType, maxDelta, minDelta, active, enabled, mode, prompt, refreshing, title, progressViewOffset, automaticallyAdjustContentInsets, bounces, bouncesZoom, alwaysBounceHorizontal, alwaysBounceVertical, centerContent, horizontal, indicatorStyle, directionalLockEnabled, canCancelContentTouches, keyboardDismissMode, keyboardShouldPersistTaps, maximumZoomScale, minimumZoomScale, pagingEnabled, scrollEventThrottle, scrollsToTop, showsHorizontalScrollIndicator, showsVerticalScrollIndicator, snapToInterval, snapToAlignment, removeClippedSubviews, zoomScale, scrollPerfTag, hidden, animated, translucent, barStyle, networkActivityIndicatorVisible, showHideTransition, itemPositioning, activeOpacity, gestureResponseDistance, enableGestures)
 
 {-| elm-native-ui Properties
 
-@docs ellipsizeMode, numberOfLines, selectable, suppressHighlighting, testID, allowFontScaling, accessible, adjustsFontSizeToFit, minimumFontScale, source, defaultSource, showsUserLocation, followUserLocation, showsPointsOfInterest, showsCompass, zoomEnabled, rotateEnabled, pitchEnabled, scrollEnabled, mapType, maxDelta, minDelta, active, enabled, mode, prompt, refreshing, title, progressViewOffset, automaticallyAdjustContentInsets, bounces, bouncesZoom, alwaysBounceHorizontal, alwaysBounceVertical, centerContent, horizontal, indicatorStyle, directionalLockEnabled, canCancelContentTouches, keyboardDismissMode, keyboardShouldPersistTaps, maximumZoomScale, minimumZoomScale, pagingEnabled, scrollEventThrottle, scrollsToTop, showsHorizontalScrollIndicator, showsVerticalScrollIndicator, snapToInterval, snapToAlignment, removeClippedSubviews, zoomScale, scrollPerfTag, hidden, animated, translucent, barStyle, networkActivityIndicatorVisible, showHideTransition, itemPositioning
+@docs ellipsizeMode, numberOfLines, selectable, suppressHighlighting, testID, allowFontScaling, accessible, adjustsFontSizeToFit, minimumFontScale, source, defaultSource, showsUserLocation, followUserLocation, showsPointsOfInterest, showsCompass, zoomEnabled, rotateEnabled, pitchEnabled, scrollEnabled, mapType, maxDelta, minDelta, active, enabled, mode, prompt, refreshing, title, progressViewOffset, automaticallyAdjustContentInsets, bounces, bouncesZoom, alwaysBounceHorizontal, alwaysBounceVertical, centerContent, horizontal, indicatorStyle, directionalLockEnabled, canCancelContentTouches, keyboardDismissMode, keyboardShouldPersistTaps, maximumZoomScale, minimumZoomScale, pagingEnabled, scrollEventThrottle, scrollsToTop, showsHorizontalScrollIndicator, showsVerticalScrollIndicator, snapToInterval, snapToAlignment, removeClippedSubviews, zoomScale, scrollPerfTag, hidden, animated, translucent, barStyle, networkActivityIndicatorVisible, showHideTransition, itemPositioning, activeOpacity, gestureResponseDistance, enableGestures
 -}
 
 import Json.Encode
 import NativeUi exposing (Property, property)
+
+
+{-| -}
+key : String -> Property msg
+key val =
+    property "key" (Json.Encode.string val)
+
 
 {-| -}
 type TextEllipsizeMode
@@ -94,12 +101,10 @@ source uri =
     property "source" (Json.Encode.object [ ( "uri", Json.Encode.string uri ) ])
 
 
-
 {-| -}
 defaultSource : String -> Property msg
 defaultSource uri =
     property "defaultSource" (Json.Encode.object [ ( "uri", Json.Encode.string uri ) ])
-
 
 
 {-| -}
@@ -558,4 +563,22 @@ itemPositioning val =
             Json.Encode.string stringValue
     in
         property "itemPositioning" jsonValue
+
+
+{-| -}
+activeOpacity : Float -> Property msg
+activeOpacity val =
+    property "activeOpacity" (Json.Encode.float val)
+
+
+{-| -}
+gestureResponseDistance : Float -> Property msg
+gestureResponseDistance val =
+    property "gestureResponseDistance" (Json.Encode.float val)
+
+
+{-| -}
+enableGestures : Bool -> Property msg
+enableGestures val =
+    property "enableGestures" (Json.Encode.bool val)
 


### PR DESCRIPTION
# Adds navigation demo - CardStack

## Main changes
* Adds TouchableHighlight, NavigationCardStack
* Adds customNodes support - eg. ability to call React.createElement for components not directly contained in ReactNative
* Adds renderProperty support - this allows for properties to contain subTrees of components that are due to be rendered. Properties that link to render methods is how NavigationExperimental defines renderScene prop which links to the view to be displayed
* Adds auto-addition of key prop when not supplied - jsx appears to also do this for some components
* Adds NavigationDemo of CardStack