### PR TITLE
Use the sysconfcpus hack for faster CI Elm builds

### DIFF
--- a/bin/ci-elm-hack.sh
+++ b/bin/ci-elm-hack.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+set -e
+
+SYSCONFCPUS="$HOME/sysconfcpus"
+ELM_MAKE="$(npm bin -g)/elm-make"
+
+# Workaround for extremely slow elm compilation
+# see https://github.com/elm-lang/elm-compiler/issues/1473#issuecomment-245704142
+if [ ! -d "$SYSCONFCPUS/bin" ];
+then
+    git clone https://github.com/obmarg/libsysconfcpus.git "$SYSCONFCPUS"
+    pushd "$SYSCONFCPUS"
+    ./configure --prefix="$SYSCONFCPUS"
+    make && make install
+    popd
+fi
+
+mv "$ELM_MAKE" "$ELM_MAKE-old"
+printf '%s\n\n' \
+       '#!/bin/bash' \
+       'echo "Running elm-make with sysconfcpus -n 2"' \
+       "$SYSCONFCPUS"'/bin/sysconfcpus -n 2 '"$ELM_MAKE"'-old "$@"' \
+       > "$ELM_MAKE"
+chmod +x "$ELM_MAKE"

--- a/circle.yml
+++ b/circle.yml
@@ -2,10 +2,11 @@ machine:
   pre:
     - npm install --silent -g elm@0.18.0
 dependencies:
-  override:
-    - elm make --yes
   cache_directories:
     - elm-stuff
+    - ~/sysconfcpus
+  override:
+    - ./bin/ci-elm-hack.sh
 test:
   override:
-    - echo "Build success!"
+    - elm make --yes


### PR DESCRIPTION
Brings builds down to ~1m30s.

Thanks to @michalmuskala for the Circle CI script:

https://github.com/michalmuskala/hex_view/blob/051dd62abcfd22c0fc763512ab4b06b02fc5920a/scripts/ci-elm-hack.sh