### PR TITLE
Add initial ListView implementation

### DIFF
--- a/elm-package.json
+++ b/elm-package.json
@@ -13,6 +13,7 @@
         "NativeUi.Properties",
         "NativeUi.Events",
         "NativeUi.AsyncStorage",
+        "NativeUi.ListView",
         "NativeUi.NavigationExperimental",
         "NativeApi.Animated",
         "NativeApi.NavigationStateUtil"

--- a/src/Native/NativeUi.js
+++ b/src/Native/NativeUi.js
@@ -39,9 +39,17 @@ var _ohanhi$elm_native_ui$Native_NativeUi = (function () {
     };
   }
 
-  function renderProperty(propName, decoder, value) {
+  function renderProperty(propName, value) {
     return {
       type: 'renderProp',
+      propName: propName,
+      value: value,
+    };
+  }
+
+  function unsafeRenderDecodedProperty(propName, decoder, value) {
+    return {
+      type: 'renderDecodedProp',
       propName: propName,
       value: value,
       decoder: decoder
@@ -156,6 +164,22 @@ var _ohanhi$elm_native_ui$Native_NativeUi = (function () {
    */
   function makeRenderNodePropHandler(fact, eventNode, key) {
     function handler(props) {
+      return renderTree(handler.component(props), eventNode, key);
+    };
+
+    handler.component = fact.value;
+
+    return handler;
+  }
+
+  /**
+   * Converts a fact whose value is a function that renders a subTree into a
+   * function that constructs the subTree to render with the provided props.
+   * This is used by NavigationExperimental to pass the header and scene views
+   * into the component
+   */
+  function makeRenderNodeDecodedPropHandler(fact, eventNode, key) {
+    function handler(props) {
       var decodedProps = decodeValue(handler.decoder, props);
 
       return renderTree(handler.component(decodedProps), eventNode, key);
@@ -229,6 +253,10 @@ var _ohanhi$elm_native_ui$Native_NativeUi = (function () {
 
         case 'renderProp':
           finalProps[fact.propName] = makeRenderNodePropHandler(fact, eventNode, key);
+          break;
+
+        case 'renderDecodedProp':
+          finalProps[fact.propName] = makeRenderNodeDecodedPropHandler(fact, eventNode, key);
           break;
 	  
         case 'event':
@@ -376,7 +404,8 @@ var _ohanhi$elm_native_ui$Native_NativeUi = (function () {
     on: F2(on),
     style: style,
     property: F2(property),
-    renderProperty: F3(renderProperty),
+    renderProperty: F2(renderProperty),
+    unsafeRenderDecodedProperty: F3(unsafeRenderDecodedProperty),
     encodeDate: identity,
     parseDate: parseDate
   };

--- a/src/Native/NativeUi/ListView.js
+++ b/src/Native/NativeUi/ListView.js
@@ -1,0 +1,28 @@
+const _ohanhi$elm_native_ui$Native_NativeUi_ListView = function () {
+  const React = require('react');
+  const { ListView, Text } = require('react-native');
+
+  const emptyDataSource = new ListView.DataSource({
+    rowHasChanged: function (a, b) { return a !== b; }
+  });
+
+  function unencodedProperty(dataSource) {
+    return {
+      type: 'prop',
+      propName: 'dataSource',
+      value: dataSource
+    };
+  }
+
+  function updateDataSource(dataSource, data) {
+    var result = _elm_lang$core$Native_List.toArray(data);
+    return dataSource.cloneWithRows(result);
+  }
+
+  return {
+    view: ListView,
+    emptyDataSource: emptyDataSource,
+    unencodedProperty: unencodedProperty,
+    updateDataSource: F2(updateDataSource),
+  };
+}();

--- a/src/NativeUi.elm
+++ b/src/NativeUi.elm
@@ -1,9 +1,23 @@
-module NativeUi exposing (Node, customNode, node, string, style, on, Property, property, map, program, renderProperty)
+module NativeUi
+    exposing
+        ( Node
+        , customNode
+        , node
+        , string
+        , style
+        , on
+        , Property
+        , property
+        , map
+        , program
+        , renderProperty
+        , unsafeRenderDecodedProperty
+        )
 
 {-| Render your application as a React Native app.
 
 # Common Helpers
-@docs node, string, customNode, style, property, map, renderProperty
+@docs node, string, customNode, style, property, map, renderProperty, unsafeRenderDecodedProperty
 
 # Events
 @docs on
@@ -63,10 +77,32 @@ property =
     Native.NativeUi.property
 
 
-{-| -}
-renderProperty : String -> Decoder a -> (a -> Node b) -> Property msg
+{-| Returns a property representing a rendering function
+
+This is usually used for properties where the values passed to the rendering
+function where created in Elm. To decode values passed from JavaScript, use
+`unsafeRenderDecodedProperty`.
+
+-}
+renderProperty : String -> (a -> Node b) -> Property msg
 renderProperty =
     Native.NativeUi.renderProperty
+
+
+{-| Returns a property representing a rendering function
+
+Runs values through the decoder before being passed to the rendering function.
+
+This is usually used for properties where the values passed to the
+rendering function were created in JavaScript, and thus need to be decoded. If
+the values are passed from Elm, you can use `renderProperty` to avoid
+encoding/decoding.
+
+Crashes the program if decoding fails.
+-}
+unsafeRenderDecodedProperty : String -> Decoder a -> (a -> Node b) -> Property msg
+unsafeRenderDecodedProperty =
+    Native.NativeUi.unsafeRenderDecodedProperty
 
 
 {-| -}

--- a/src/NativeUi/ListView.elm
+++ b/src/NativeUi/ListView.elm
@@ -1,0 +1,86 @@
+module NativeUi.ListView
+    exposing
+        ( DataSource
+        , emptyDataSource
+        , listView
+        , updateDataSource
+        , initialListSize
+        , pageSize
+        , removeClippedSubviews
+        , scrollRenderAheadDistance
+        )
+
+{-| elm-native-ui ListView
+
+@docs DataSource, emptyDataSource, listView, updateDataSource, initialListSize, pageSize, removeClippedSubviews, scrollRenderAheadDistance
+-}
+
+import Json.Encode
+import NativeUi exposing (Property, Node, node, renderProperty, property)
+import Native.NativeUi.ListView
+
+
+{-| -}
+type DataSource a
+    = DataSource a
+
+
+{-| -}
+listView : DataSource a -> (a -> Node msg) -> List (Property msg) -> Node msg
+listView ds render props =
+    node "ListView"
+        ((unencodedProperty
+            ds
+         )
+            :: renderRow render
+            :: props
+        )
+        []
+
+
+{-| -}
+renderRow : (a -> Node msg) -> Property msg
+renderRow =
+    renderProperty "renderRow"
+
+
+{-| -}
+emptyDataSource : DataSource a
+emptyDataSource =
+    Native.NativeUi.ListView.emptyDataSource
+
+
+{-| -}
+updateDataSource : DataSource a -> List a -> DataSource a
+updateDataSource =
+    Native.NativeUi.ListView.updateDataSource
+
+
+{-| -}
+unencodedProperty : DataSource a -> Property msg
+unencodedProperty =
+    Native.NativeUi.ListView.unencodedProperty
+
+
+{-| -}
+initialListSize : Int -> Property msg
+initialListSize =
+    property "initialListSize" << Json.Encode.int
+
+
+{-| -}
+pageSize : Int -> Property msg
+pageSize =
+    property "pageSize" << Json.Encode.int
+
+
+{-| -}
+removeClippedSubviews : Bool -> Property msg
+removeClippedSubviews =
+    property "removeClippedSubviews" << Json.Encode.bool
+
+
+{-| -}
+scrollRenderAheadDistance : Int -> Property msg
+scrollRenderAheadDistance =
+    property "scrollRenderAheadDistance" << Json.Encode.int

--- a/src/NativeUi/NavigationExperimental.elm
+++ b/src/NativeUi/NavigationExperimental.elm
@@ -187,18 +187,6 @@ type alias NavigationSceneRenderer =
     }
 
 
-encodeNavigationSceneRenderer : NavigationSceneRenderer -> Value
-encodeNavigationSceneRenderer props =
-    Encode.object <|
-        [ ( "layout", encodeNavigationLayout props.layout )
-        , ( "navigationState", encodeNavigationState props.navigationState )
-        , ( "position", encodeAnimatedValue props.position )
-        , ( "progress", encodeAnimatedValue props.progress )
-        , ( "scene", encodeNavigationScene props.scene )
-        , ( "scenes", Encode.list <| List.map encodeNavigationScene props.scenes )
-        ]
-
-
 decodeNavigationSceneRenderer : Decode.Decoder NavigationSceneRenderer
 decodeNavigationSceneRenderer =
     Decode.map6 NavigationSceneRenderer

--- a/src/NativeUi/NavigationExperimental.elm
+++ b/src/NativeUi/NavigationExperimental.elm
@@ -8,7 +8,7 @@ import Json.Decode as Decode
 import Json.Encode as Encode exposing (Value, bool, int, list, object, string)
 import Native.NativeUi
 import NativeApi.Animated exposing (AnimatedValue, decodeAnimatedValue, encodeAnimatedValue)
-import NativeUi exposing (Node, Property, on, property, renderProperty)
+import NativeUi exposing (Node, Property, on, property, unsafeRenderDecodedProperty)
 import NativeUi.Style as Style
 
 
@@ -18,19 +18,19 @@ import NativeUi.Style as Style
 {-| -}
 renderHeader : (NavigationSceneRenderer -> Node a) -> Property msg
 renderHeader =
-    renderProperty "renderHeader" decodeNavigationSceneRenderer
+    unsafeRenderDecodedProperty "renderHeader" decodeNavigationSceneRenderer
 
 
 {-| -}
 renderScene : (NavigationSceneRenderer -> Node a) -> Property msg
 renderScene =
-    renderProperty "renderScene" decodeNavigationSceneRenderer
+    unsafeRenderDecodedProperty "renderScene" decodeNavigationSceneRenderer
 
 
 {-| -}
 renderTitleComponent : (NavigationSceneRenderer -> Node a) -> Property msg
 renderTitleComponent =
-    renderProperty "renderTitleComponent" decodeNavigationSceneRenderer
+    unsafeRenderDecodedProperty "renderTitleComponent" decodeNavigationSceneRenderer
 
 
 


### PR DESCRIPTION
Due to the imperative nature of ListView, this implementation doesn't
really work well with the Elm architecture, forcing you to manually keep
a DataSource up to date.

An experimental alternative called [FlatList](https://medium.com/@cooperka/react-native-new-flatlist-component-30db558c7a5b#.3kodtbtz7) was recently added to ReactNative which is
likely a better long term fit, but this works in the meantime.

There are still a handful of commonly used functions that @jferris and I didn't get around to implementing, but this at least provides the bare minimum.

Example use:

    type alias Model =
      { wombats : List Wombat
      , wombatDataSource : DataSource Wombat
      }

    view model =
      listView
        model.wombatDataSource
        wombatView
        [ Ui.style
            [ Style.backgroundColor Color.white
            ]
        ]

    update msg model =
      LoadWombats wombats ->
        let
            wombatDataSource = updateDataSource model.wombatDataSource wombats
        in
          ( { model | wombats = wombats, wombatDataSource = wombatDataSource }, Cmd.none )