### PR TITLE
NativeApi.Platform.os to check OS

### DIFF
--- a/elm-package.json
+++ b/elm-package.json
@@ -15,7 +15,8 @@
         "NativeUi.AsyncStorage",
         "NativeUi.NavigationExperimental",
         "NativeApi.Animated",
-        "NativeApi.NavigationStateUtil"
+        "NativeApi.NavigationStateUtil",
+        "NativeApi.Platform"
     ],
     "native-modules": true,
     "dependencies": {

--- a/src/Native/NativeUi/Platform.js
+++ b/src/Native/NativeUi/Platform.js
@@ -1,0 +1,7 @@
+const _ohanhi$elm_native_ui$Native_NativeUi_Platform = function () {
+  const { Platform } = require("react-native");
+
+  return {
+    os: Platform.OS,
+  }
+}();

--- a/src/NativeApi/Platform.elm
+++ b/src/NativeApi/Platform.elm
@@ -1,0 +1,23 @@
+module NativeApi.Platform exposing (OS(..), os)
+
+{-| elm-native-ui Platform
+
+@docs OS, os
+-}
+
+import Native.NativeUi.Platform
+
+
+{-| -}
+type OS
+    = Android
+    | IOS
+
+
+{-| -}
+os : OS
+os =
+    if Native.NativeUi.Platform.os == "ios" then
+        IOS
+    else
+        Android


### PR DESCRIPTION
This adds a `NativeApi.Platform` module, which exposes an `os` function.
It returns a `NativeApi.Platform.OS` union type, which is either
`Android` or `IOS`.

So in your app, you can now check for the platform:

```elm
import NativeApi.Platform as Platform exposing (OS(..))

topMargin : Float
topMargin =
    case Platform.os of
        Android ->
            10

        IOS ->
            20
```