### PR TITLE
ref support and some style addition

### DIFF
--- a/src/Native/NativeUi.js
+++ b/src/Native/NativeUi.js
@@ -16,7 +16,15 @@ var _ohanhi$elm_native_ui$Native_NativeUi = (function () {
       decoder: decoder
     };
   }
-
+  /**
+   * Declares a ref attribute for a node, callback receives the reference of the node
+   */
+  function ref(callback) {
+    return {
+      type: 'ref',
+      callback: callback,
+    }
+  }
   /**
    * Declares a style attribute for a node, expressed as an inline styles for
    * the moment.
@@ -226,7 +234,9 @@ var _ohanhi$elm_native_ui$Native_NativeUi = (function () {
         case 'prop':
           finalProps[fact.propName] = fact.value;
           break;
-
+        case 'ref':
+          finalProps['ref'] = fact.callback;
+          break;
         case 'renderProp':
           finalProps[fact.propName] = makeRenderNodePropHandler(fact, eventNode, key);
           break;
@@ -250,8 +260,9 @@ var _ohanhi$elm_native_ui$Native_NativeUi = (function () {
     } else if (children.length) {
       finalProps.children = children;
     }
-
-    if (ReactNative[node.tagName]) {
+    // ignore MapView exported from current react-native package since we want to use one from react-native-maps
+    // release of 0.42 will remove this.
+    if (node.tagName !== 'MapView' && ReactNative[node.tagName]) {
       return React.createElement(ReactNative[node.tagName], finalProps);
     } else {
       if (!node.nativeComponent) {
@@ -374,6 +385,7 @@ var _ohanhi$elm_native_ui$Native_NativeUi = (function () {
     string: string,
     map: F2(map),
     on: F2(on),
+    ref: ref,
     style: style,
     property: F2(property),
     renderProperty: F3(renderProperty),

--- a/src/NativeUi/Style.elm
+++ b/src/NativeUi/Style.elm
@@ -55,6 +55,8 @@ module NativeUi.Style
         , marginTop
         , marginHorizontal
         , marginVertical
+        , minHeight
+        , maxHeight
         , padding
         , paddingLeft
         , paddingRight
@@ -66,6 +68,7 @@ module NativeUi.Style
         , right
         , top
         , width
+        , zIndex
         , Transform
         , defaultTransform
         , transform
@@ -547,6 +550,16 @@ marginVertical =
     numberStyle "marginVertical"
 
 
+minHeight : Float -> Style
+minHeight =
+    numberStyle "minHeight"
+
+
+maxHeight : Float -> Style
+maxHeight =
+    numberStyle "maxHeight"
+
+
 {-| -}
 padding : Float -> Style
 padding =
@@ -612,6 +625,12 @@ top =
 width : Float -> Style
 width =
     numberStyle "width"
+
+
+{-| -}
+zIndex : Float -> Style
+zIndex =
+    numberStyle "zIndex"
 
 
 


### PR DESCRIPTION
I have been working on the integration of [react-native-maps](https://github.com/airbnb/react-native-maps), and it is working pretty well. In that process I realized the needs of `ref` property for supporting imperative methods. 

The actual usage is like follows.

```
const _ohanhi$elm_native_ui$Native_NativeUi_MapView = function () {
  const map = require('react-native-maps');
  const maps = {};

  function refMap(el) {
    maps[el.props.id] = el;
  }

  function animateToRegion(id, region, duration) {
    return _elm_lang$core$Native_Scheduler.nativeBinding(function(callback) {
      maps[id].animateToRegion(region, duration);
      return callback(_elm_lang$core$Native_Scheduler.succeed(unit));
    });
  }

  return {
    map: map,
    refMap: refMap,
    animateToRegion: F3(animateToRegion),
  };
}();
```