### PR TITLE
modify Image source property to handle static images

### DIFF
--- a/examples/Counter/Main.elm
+++ b/examples/Counter/Main.elm
@@ -53,7 +53,7 @@ view count =
                 , Style.width 64
                 , Style.marginBottom 30
                 ]
-            , source "https://raw.githubusercontent.com/futurice/spiceprogram/master/assets/img/logo/chilicorn_no_text-128.png"
+            , sourceUri "https://raw.githubusercontent.com/futurice/spiceprogram/master/assets/img/logo/chilicorn_no_text-128.png"
             ]
             []
         , text

--- a/src/NativeUi/Properties.elm
+++ b/src/NativeUi/Properties.elm
@@ -1,8 +1,8 @@
-module NativeUi.Properties exposing (key, ellipsizeMode, numberOfLines, selectable, suppressHighlighting, testID, allowFontScaling, accessible, adjustsFontSizeToFit, minimumFontScale, source, defaultSource, showsUserLocation, followUserLocation, showsPointsOfInterest, showsCompass, zoomEnabled, rotateEnabled, pitchEnabled, scrollEnabled, mapType, maxDelta, minDelta, active, enabled, mode, prompt, refreshing, title, progressViewOffset, automaticallyAdjustContentInsets, bounces, bouncesZoom, alwaysBounceHorizontal, alwaysBounceVertical, centerContent, horizontal, indicatorStyle, directionalLockEnabled, canCancelContentTouches, keyboardDismissMode, keyboardShouldPersistTaps, maximumZoomScale, minimumZoomScale, pagingEnabled, scrollEventThrottle, scrollsToTop, showsHorizontalScrollIndicator, showsVerticalScrollIndicator, snapToInterval, snapToAlignment, removeClippedSubviews, zoomScale, scrollPerfTag, hidden, animated, translucent, barStyle, networkActivityIndicatorVisible, showHideTransition, itemPositioning, activeOpacity, gestureResponseDistance, enableGestures, statusBarHeight)
+module NativeUi.Properties exposing (key, ellipsizeMode, numberOfLines, selectable, suppressHighlighting, testID, allowFontScaling, accessible, adjustsFontSizeToFit, minimumFontScale, source, sourceUri, defaultSource, defaultSourceUri, showsUserLocation, followUserLocation, showsPointsOfInterest, showsCompass, zoomEnabled, rotateEnabled, pitchEnabled, scrollEnabled, mapType, maxDelta, minDelta, active, enabled, mode, prompt, refreshing, title, progressViewOffset, automaticallyAdjustContentInsets, bounces, bouncesZoom, alwaysBounceHorizontal, alwaysBounceVertical, centerContent, horizontal, indicatorStyle, directionalLockEnabled, canCancelContentTouches, keyboardDismissMode, keyboardShouldPersistTaps, maximumZoomScale, minimumZoomScale, pagingEnabled, scrollEventThrottle, scrollsToTop, showsHorizontalScrollIndicator, showsVerticalScrollIndicator, snapToInterval, snapToAlignment, removeClippedSubviews, zoomScale, scrollPerfTag, hidden, animated, translucent, barStyle, networkActivityIndicatorVisible, showHideTransition, itemPositioning, activeOpacity, gestureResponseDistance, enableGestures, statusBarHeight)
 
 {-| elm-native-ui Properties
 
-@docs key, ellipsizeMode, numberOfLines, selectable, suppressHighlighting, testID, allowFontScaling, accessible, adjustsFontSizeToFit, minimumFontScale, source, defaultSource, showsUserLocation, followUserLocation, showsPointsOfInterest, showsCompass, zoomEnabled, rotateEnabled, pitchEnabled, scrollEnabled, mapType, maxDelta, minDelta, active, enabled, mode, prompt, refreshing, title, progressViewOffset, automaticallyAdjustContentInsets, bounces, bouncesZoom, alwaysBounceHorizontal, alwaysBounceVertical, centerContent, horizontal, indicatorStyle, directionalLockEnabled, canCancelContentTouches, keyboardDismissMode, keyboardShouldPersistTaps, maximumZoomScale, minimumZoomScale, pagingEnabled, scrollEventThrottle, scrollsToTop, showsHorizontalScrollIndicator, showsVerticalScrollIndicator, snapToInterval, snapToAlignment, removeClippedSubviews, zoomScale, scrollPerfTag, hidden, animated, translucent, barStyle, networkActivityIndicatorVisible, showHideTransition, itemPositioning, activeOpacity, gestureResponseDistance, enableGestures, statusBarHeight
+@docs key, ellipsizeMode, numberOfLines, selectable, suppressHighlighting, testID, allowFontScaling, accessible, adjustsFontSizeToFit, minimumFontScale, source, sourceUri, defaultSource, defaultSourceUri, showsUserLocation, followUserLocation, showsPointsOfInterest, showsCompass, zoomEnabled, rotateEnabled, pitchEnabled, scrollEnabled, mapType, maxDelta, minDelta, active, enabled, mode, prompt, refreshing, title, progressViewOffset, automaticallyAdjustContentInsets, bounces, bouncesZoom, alwaysBounceHorizontal, alwaysBounceVertical, centerContent, horizontal, indicatorStyle, directionalLockEnabled, canCancelContentTouches, keyboardDismissMode, keyboardShouldPersistTaps, maximumZoomScale, minimumZoomScale, pagingEnabled, scrollEventThrottle, scrollsToTop, showsHorizontalScrollIndicator, showsVerticalScrollIndicator, snapToInterval, snapToAlignment, removeClippedSubviews, zoomScale, scrollPerfTag, hidden, animated, translucent, barStyle, networkActivityIndicatorVisible, showHideTransition, itemPositioning, activeOpacity, gestureResponseDistance, enableGestures, statusBarHeight
 
 -}
 
@@ -98,13 +98,25 @@ minimumFontScale val =
 
 {-| -}
 source : String -> Property msg
-source uri =
+source image =
+    property "source" (Json.Encode.string image)
+
+
+{-| -}
+sourceUri : String -> Property msg
+sourceUri uri =
     property "source" (Json.Encode.object [ ( "uri", Json.Encode.string uri ) ])
 
 
 {-| -}
 defaultSource : String -> Property msg
-defaultSource uri =
+defaultSource image =
+    property "defaultSource" (Json.Encode.string image)
+
+
+{-| -}
+defaultSourceUri : String -> Property msg
+defaultSourceUri uri =
     property "defaultSource" (Json.Encode.object [ ( "uri", Json.Encode.string uri ) ])
 
 


### PR DESCRIPTION
Loading local static images in `elm-native-ui` is not obvious. So I have figured out how to do that and suggesting a small API change. The React Native doc about Image loading is [here](http://facebook.github.io/react-native/releases/0.41/docs/images.html#images). 

Here is a simple description what this modification makes possible.

All images are referenced by relative to `elm.js`, so the directory structure become like follows.
```
.
├── src
|   └── Native
|       └── Image.js
├── elm.js
└── img
    ├── check@2x.png
    └── check@3x.png
```

We need a small Native module to require the image files then return them as an object. The content of `src/Native/Images.js` is
``` 
var _ohanhi$elm_native_ui$Native_Images = (function () {
  return {
   check : require('./img/check.png’);,
  };
}());
```

In an Elm code, you can load this image like this.
```
[ Elements.image
    [ Properties.source Image.check
    ] []
]
```
If you want to load an image from remote like before, change the property name to `sourceUri`.
```
[ Elements.image
    [ Properties.sourceUri "http://somedomain.com/sample.png"
    ] []
]
```
