### PR TITLE
Add Dimensions module to get the window size

### DIFF
--- a/elm-package.json
+++ b/elm-package.json
@@ -16,6 +16,7 @@
         "NativeUi.ListView",
         "NativeUi.NavigationExperimental",
         "NativeApi.Animated",
+        "NativeApi.Dimensions",
         "NativeApi.NavigationStateUtil",
         "NativeApi.Platform"
     ],

--- a/src/Native/NativeUi/Dimensions.js
+++ b/src/Native/NativeUi/Dimensions.js
@@ -1,0 +1,9 @@
+const _ohanhi$elm_native_ui$Native_NativeUi_Dimensions = function () {
+  const { Dimensions } = require('react-native');
+  const { height, width } = Dimensions.get('window');
+
+  return {
+    windowHeight: height,
+    windowWidth: width,
+  };
+}();

--- a/src/Native/NativeUi/Platform.js
+++ b/src/Native/NativeUi/Platform.js
@@ -3,5 +3,5 @@ const _ohanhi$elm_native_ui$Native_NativeUi_Platform = function () {
 
   return {
     os: Platform.OS,
-  }
+  };
 }();

--- a/src/NativeApi/Dimensions.elm
+++ b/src/NativeApi/Dimensions.elm
@@ -1,0 +1,21 @@
+module NativeApi.Dimensions exposing (window)
+
+{-| elm-native-ui Dimensions
+
+@docs window
+-}
+
+import Native.NativeUi.Dimensions
+
+
+{-| -}
+type alias WindowSize =
+    { height : Float, width : Float }
+
+
+{-| -}
+window : WindowSize
+window =
+    WindowSize
+        Native.NativeUi.Dimensions.windowHeight
+        Native.NativeUi.Dimensions.windowWidth

--- a/src/NativeUi/Style.elm
+++ b/src/NativeUi/Style.elm
@@ -76,7 +76,7 @@ module NativeUi.Style
 
 {-| Style your elements
 
-@docs Style, encode, color, fontFamily, fontSize, fontWeight, letterSpacing, lineHeight, textAlign, textDecorationLine, textDecorationStyle, textDecorationColor, writingDirection, backfaceVisibility, backgroundColor, borderColor, borderStyle, borderWidth, borderRadius, borderTopColor, borderTopWidth, borderTopLeftRadius, borderTopRightRadius, borderLeftColor, borderLeftWidth, borderBottomColor, borderBottomWidth, borderBottomLeftRadius, borderBottomRightRadius, borderRightColor, borderRightWidth, overflow, opacity, shadowColor, shadowOffset, shadowRadius, shadowOpacity, resizeMode, tintColor, alignItems, alignSelf, bottom, flex, flexDirection, flexWrap, height, justifyContent, left, margin, marginBottom, marginLeft, marginRight, marginTop, marginHorizontal, marginVertical, padding, paddingLeft, paddingRight, paddingTop, paddingBottom, paddingHorizontal, paddingVertical, position, right, top, width, Transform, defaultTransform, transform
+@docs Style, encode, color, fontFamily, fontSize, fontWeight, letterSpacing, lineHeight, textAlign, textDecorationLine, textDecorationStyle, textDecorationColor, writingDirection, backfaceVisibility, backgroundColor, borderColor, borderStyle, borderWidth, borderRadius, borderTopColor, borderTopWidth, borderTopLeftRadius, borderTopRightRadius, borderLeftColor, borderLeftWidth, borderBottomColor, borderBottomWidth, borderBottomLeftRadius, borderBottomRightRadius, borderRightColor, borderRightWidth, overflow, opacity, shadowColor, shadowOffset, shadowRadius, shadowOpacity, resizeMode, tintColor, alignItems, alignSelf, bottom, flex, flexDirection, flexWrap, height, justifyContent, left, margin, marginBottom, marginLeft, marginRight, marginTop, marginHorizontal, marginVertical, maxHeight, minHeight, padding, paddingLeft, paddingRight, paddingTop, paddingBottom, paddingHorizontal, paddingVertical, position, right, top, width, Transform, defaultTransform, transform, zIndex
 
 -}
 
@@ -550,11 +550,13 @@ marginVertical =
     numberStyle "marginVertical"
 
 
+{-| -}
 minHeight : Float -> Style
 minHeight =
     numberStyle "minHeight"
 
 
+{-| -}
 maxHeight : Float -> Style
 maxHeight =
     numberStyle "maxHeight"


### PR DESCRIPTION
This is useful, for example, to implement "responsive" styles by scaling values up/down based on the screen size.

Usage:

```elm
import NativeApi.Dimensions exposing (window)

windowHeight =
    window.height

windowWidth =
    window.width
```