### PR TITLE
Refactor NativeUi.elm to use point-free style

### DIFF
--- a/src/NativeUi.elm
+++ b/src/NativeUi.elm
@@ -117,8 +117,15 @@ style =
 
 {-| -}
 on : String -> Decoder msg -> Property msg
-on =
-    Native.NativeUi.on << ((++) "on")
+on eventName =
+    let
+        realEventName =
+            if String.startsWith "on" eventName then
+                eventName
+            else
+                "on" ++ eventName
+    in
+        Native.NativeUi.on realEventName
 
 
 {-| -}

--- a/src/NativeUi.elm
+++ b/src/NativeUi.elm
@@ -111,19 +111,14 @@ unsafeRenderDecodedProperty =
 
 {-| -}
 style : List Style.Style -> Property msg
-style styles =
-    Style.encode styles
-        |> Native.NativeUi.style
+style =
+    Native.NativeUi.style << Style.encode
 
 
 {-| -}
 on : String -> Decoder msg -> Property msg
-on eventName =
-    let
-        realEventName =
-            "on" ++ eventName
-    in
-        Native.NativeUi.on realEventName
+on =
+    Native.NativeUi.on << ((++) "on")
 
 
 {-| -}
@@ -134,8 +129,8 @@ ref =
 
 {-| -}
 map : (a -> b) -> Node a -> Node b
-map tagger element =
-    Native.NativeUi.map tagger element
+map =
+    Native.NativeUi.map
 
 
 {-| -}
@@ -146,5 +141,5 @@ program :
     , init : ( model, Cmd msg )
     }
     -> Program Never model msg
-program stuff =
-    Native.NativeUi.program stuff
+program =
+    Native.NativeUi.program


### PR DESCRIPTION
Was just reading through it and found some places that could be refactored to use point-free style. I checked the `.js` equivalents to make sure they're wrapped in `FN` functions (where `N` is number of arguments), but since there were no tests (and I didn't have time to look into writing any) I can't be 100% sure it works, so please look over before (if) merging :)