### PR TITLE
Allow accessing app (and thus ports) via callback to start

### DIFF
--- a/src/Native/NativeUi.js
+++ b/src/Native/NativeUi.js
@@ -325,11 +325,13 @@ var _ohanhi$elm_native_ui$Native_NativeUi = (function () {
    * component that will begin rendering the virtual tree as soon as the Elm
    * program starts running
    */
-  function makeComponent(impl) {
+  function makeComponent(impl, onAppReady) {
     return React.createClass({
       getInitialState: function getInitialState() {
         return {};
       },
+
+      onAppReady: onAppReady,
 
       componentDidMount: function componentDidMount() {
         this.eventNode = { tagger: function() {}, parent: undefined };
@@ -340,6 +342,10 @@ var _ohanhi$elm_native_ui$Native_NativeUi = (function () {
           impl.subscriptions,
           this.renderer
         );
+
+        if (typeof this.onAppReady === "function") {
+          this.onAppReady(this._app);
+        }
       },
 
       renderer: function renderer(onMessage, initialModel) {
@@ -374,8 +380,8 @@ var _ohanhi$elm_native_ui$Native_NativeUi = (function () {
   function program(impl) {
     return function(flagDecoder) {
       return function(object, moduleName, debugMetadata) {
-        object.start = function start() {
-          return makeComponent(impl);
+        object.start = function start(onAppReady) {
+          return makeComponent(impl, onAppReady);
         };
       };
     };


### PR DESCRIPTION
**Disclaimer**: If this exists and I just blatantly missed it, sorry. I've spent way too much time trying to figure out where the ports might be hidden, and finally descended into the git history of elm-native-ui and found some remnants of a callback that I decided to piece "back" together. If this doesn't make sense or is superfluous, just close and please, tell me where ports are 😅 

Allow passing a callback function to start that is, upon app
initialization, called with the app instance as a single argument. This
lets you, e.g., set up ports with something like this:
```
const component = Elm.Main.start(app => {
  app.ports.something.subscribe(doStuff)
})
```