### PR TITLE
If we have ports why not flags...

### DIFF
--- a/src/Native/NativeUi.js
+++ b/src/Native/NativeUi.js
@@ -410,7 +410,7 @@ var _ohanhi$elm_native_ui$Native_NativeUi = (function () {
           		+ result._0
           	);
           }
-          return makeComponent(impl, onAppReady, result);
+          return makeComponent(impl, onAppReady, result._0);
         };
       };
     };

--- a/src/Native/NativeUi.js
+++ b/src/Native/NativeUi.js
@@ -405,26 +405,12 @@ var _ohanhi$elm_native_ui$Native_NativeUi = (function () {
           if (result.ctor === 'Err')
           {
           	throw new Error(
-          		moduleName + '.worker(...) was called with an unexpected argument.\n'
+          		moduleName + '.start(...) was called with an unexpected argument.\n'
           		+ 'I tried to convert it to an Elm value, but ran into this problem:\n\n'
           		+ result._0
           	);
           }
           return makeComponent(impl, onAppReady, result);
-        };
-      };
-    };
-  }
-
-  /**
-   * This is unsafe since it passes `flags` object wihout running the `flagDecoder`.
-   * Useful for passing down injected JS props to another JS functions in native codes.
-   */
-  function unsafeProgramWithFlags(impl) {
-    return function(flagDecoder) {
-      return function(object, moduleName, debugMetadata) {
-        object.start = function start(onAppReady, flags = {}) {
-          return makeComponent(impl, onAppReady, flags);
         };
       };
     };
@@ -457,7 +443,6 @@ var _ohanhi$elm_native_ui$Native_NativeUi = (function () {
   return {
     program: program,
     programWithFlags: programWithFlags,
-    unsafeProgramWithFlags: unsafeProgramWithFlags,
     node: node,
     voidNode: voidNode,
     customNode: F2(customNode),

--- a/src/NativeUi.elm
+++ b/src/NativeUi.elm
@@ -11,6 +11,8 @@ module NativeUi
         , property
         , map
         , program
+        , programWithFlags
+        , unsafeProgramWithFlags
         , renderProperty
         , unsafeRenderDecodedProperty
         )
@@ -30,7 +32,7 @@ module NativeUi
 @docs Node, Property
 
 # Program
-@docs program
+@docs program, programWithFlags, unsafeProgramWithFlags
 -}
 
 import Json.Decode as Decode exposing (Value, Decoder)
@@ -150,3 +152,27 @@ program :
     -> Program Never model msg
 program =
     Native.NativeUi.program
+
+
+{-| -}
+programWithFlags :
+    { view : model -> Node msg
+    , update : msg -> model -> ( model, Cmd msg )
+    , subscriptions : model -> Sub msg
+    , init : flags -> ( model, Cmd msg )
+    }
+    -> Program flags model msg
+programWithFlags stuff =
+    Native.NativeUi.programWithFlags stuff
+
+
+{-| -}
+unsafeProgramWithFlags :
+    { view : model -> Node msg
+    , update : msg -> model -> ( model, Cmd msg )
+    , subscriptions : model -> Sub msg
+    , init : flags -> ( model, Cmd msg )
+    }
+    -> Program flags model msg
+unsafeProgramWithFlags stuff =
+    Native.NativeUi.unsafeProgramWithFlags stuff

--- a/src/NativeUi.elm
+++ b/src/NativeUi.elm
@@ -12,7 +12,6 @@ module NativeUi
         , map
         , program
         , programWithFlags
-        , unsafeProgramWithFlags
         , renderProperty
         , unsafeRenderDecodedProperty
         )
@@ -32,7 +31,7 @@ module NativeUi
 @docs Node, Property
 
 # Program
-@docs program, programWithFlags, unsafeProgramWithFlags
+@docs program, programWithFlags
 -}
 
 import Json.Decode as Decode exposing (Value, Decoder)
@@ -162,17 +161,5 @@ programWithFlags :
     , init : flags -> ( model, Cmd msg )
     }
     -> Program flags model msg
-programWithFlags stuff =
-    Native.NativeUi.programWithFlags stuff
-
-
-{-| -}
-unsafeProgramWithFlags :
-    { view : model -> Node msg
-    , update : msg -> model -> ( model, Cmd msg )
-    , subscriptions : model -> Sub msg
-    , init : flags -> ( model, Cmd msg )
-    }
-    -> Program flags model msg
-unsafeProgramWithFlags stuff =
-    Native.NativeUi.unsafeProgramWithFlags stuff
+programWithFlags =
+    Native.NativeUi.programWithFlags


### PR DESCRIPTION
The title says about adding Flags support, but actually I needed a way to pass a JS props object to native JS functions through Elm program without knowing details, that means no decoding and encoding. `unsafeProgramWithFlags` is pretty useful for such case though no guarantee of type safety. I will show you my usage if necessary.

