### PR TITLE
Add ability to specify Image source with uri and cache

### DIFF
--- a/examples/Counter/Main.elm
+++ b/examples/Counter/Main.elm
@@ -3,8 +3,8 @@ module Main exposing (..)
 import NativeUi as Ui exposing (Node)
 import NativeUi.Style as Style exposing (defaultTransform)
 import NativeUi.Elements as Elements exposing (..)
-import NativeUi.Properties exposing (..)
 import NativeUi.Events exposing (..)
+import NativeUi.Image as Image exposing (..)
 
 
 -- MODEL
@@ -44,37 +44,44 @@ update msg model =
 
 view : Model -> Node Msg
 view count =
-    Elements.view
-        [ Ui.style [ Style.alignItems "center" ]
-        ]
-        [ image
-            [ Ui.style
-                [ Style.height 64
-                , Style.width 64
-                , Style.marginBottom 30
+    let
+        imageSource =
+            { uri = "https://raw.githubusercontent.com/futurice/spiceprogram/master/assets/img/logo/chilicorn_no_text-128.png"
+            , cache = Just ForceCache
+            }
+    in
+        Elements.view
+            [ Ui.style [ Style.alignItems "center" ]
+            ]
+            [ image
+                [ Ui.style
+                    [ Style.height 64
+                    , Style.width 64
+                    , Style.marginBottom 30
+                    , Style.marginTop 30
+                    ]
+                , source imageSource
                 ]
-            , sourceUri "https://raw.githubusercontent.com/futurice/spiceprogram/master/assets/img/logo/chilicorn_no_text-128.png"
-            ]
-            []
-        , text
-            [ Ui.style
-                [ Style.textAlign "center"
-                , Style.marginBottom 30
+                []
+            , text
+                [ Ui.style
+                    [ Style.textAlign "center"
+                    , Style.marginBottom 30
+                    ]
+                ]
+                [ Ui.string ("Counter: " ++ toString count)
+                ]
+            , Elements.view
+                [ Ui.style
+                    [ Style.width 80
+                    , Style.flexDirection "row"
+                    , Style.justifyContent "space-between"
+                    ]
+                ]
+                [ button Decrement "#d33" "-"
+                , button Increment "#3d3" "+"
                 ]
             ]
-            [ Ui.string ("Counter: " ++ toString count)
-            ]
-        , Elements.view
-            [ Ui.style
-                [ Style.width 80
-                , Style.flexDirection "row"
-                , Style.justifyContent "space-between"
-                ]
-            ]
-            [ button Decrement "#d33" "-"
-            , button Increment "#3d3" "+"
-            ]
-        ]
 
 
 button : Msg -> String -> String -> Node Msg

--- a/src/NativeUi/Image.elm
+++ b/src/NativeUi/Image.elm
@@ -1,0 +1,104 @@
+module NativeUi.Image
+    exposing
+        ( Source
+        , CacheStrategy(..)
+        , source
+        , defaultSource
+        )
+
+{-| elm-native-ui Image
+
+@docs Source, CacheStrategy, source
+-}
+
+import Json.Encode as Encode
+import Json.Decode as Decode
+import NativeUi exposing (Property, Node, node, renderProperty, property)
+
+
+{-| -}
+type CacheStrategy
+    = Default
+    | Reload
+    | ForceCache
+    | OnlyIfCached
+
+
+{-| -}
+type alias Source =
+    { uri : String
+    , cache : Maybe CacheStrategy
+    }
+
+
+defaultSource : String -> Source
+defaultSource uri =
+    { uri = uri, cache = Nothing }
+
+
+{-| -}
+source : Source -> Property msg
+source val =
+    property "source" (encodeSource val)
+
+
+encodeSource : Source -> Encode.Value
+encodeSource source =
+    let
+        uriEncode =
+            ( "uri", Encode.string source.uri )
+
+        mapFunc x =
+            ( "cache", encodeCacheStrategy x )
+
+        encoding =
+            [ Just uriEncode, Maybe.map mapFunc source.cache ]
+    in
+        Encode.object <| (List.filterMap identity encoding)
+
+
+encodeCacheStrategy : CacheStrategy -> Encode.Value
+encodeCacheStrategy cacheStrategy =
+    case cacheStrategy of
+        Default ->
+            Encode.string "default"
+
+        Reload ->
+            Encode.string "reload"
+
+        ForceCache ->
+            Encode.string "force-cache"
+
+        OnlyIfCached ->
+            Encode.string "only-if-cached"
+
+
+decodeSource : Decode.Decoder Source
+decodeSource =
+    Decode.map2 Source
+        (Decode.field "uri" Decode.string)
+        (Decode.field "cache" (Decode.nullable Decode.string) |> Decode.andThen decodeCacheStrategy)
+
+
+decodeCacheStrategy : Maybe String -> Decode.Decoder (Maybe CacheStrategy)
+decodeCacheStrategy optionalStringValue =
+    case optionalStringValue of
+        Nothing ->
+            Decode.succeed Nothing
+
+        Just stringValue ->
+            case stringValue of
+                "default" ->
+                    Decode.succeed (Just Default)
+
+                "reload" ->
+                    Decode.succeed (Just Reload)
+
+                "force-cache" ->
+                    Decode.succeed (Just ForceCache)
+
+                "only-if-cached" ->
+                    Decode.succeed (Just OnlyIfCached)
+
+                _ ->
+                    Decode.fail (stringValue ++ " is not a valid image cache value")

--- a/src/NativeUi/Image.elm
+++ b/src/NativeUi/Image.elm
@@ -13,7 +13,7 @@ module NativeUi.Image
 
 import Json.Encode as Encode
 import Json.Decode as Decode
-import NativeUi exposing (Property, Node, node, renderProperty, property)
+import NativeUi exposing (Property, Node, property)
 
 
 {-| -}

--- a/src/NativeUi/Image.elm
+++ b/src/NativeUi/Image.elm
@@ -31,6 +31,7 @@ type alias Source =
     }
 
 
+{-| -}
 defaultSource : String -> Source
 defaultSource uri =
     { uri = uri, cache = Nothing }


### PR DESCRIPTION
This will let you use images from local bundled assets, very simple first version, can be extended as per requirements.

Example usage:
```elm
import NativeUi.Elements as Elements exposing (..)
import NativeUi.Image as Image

imageTag : String -> Node msg
imageTag assetName =
    Elements.image
        [ Ui.style
            [ Style.height 32
            , Style.width 32
            ]
        , Image.source (Image.defaultSource assetName)
        ]
        []
```
