### PR TITLE
can pass local images to react native

### DIFF
--- a/src/NativeUi/Image.elm
+++ b/src/NativeUi/Image.elm
@@ -4,6 +4,7 @@ module NativeUi.Image
         , CacheStrategy(..)
         , source
         , defaultSource
+        , localSource
         )
 
 {-| elm-native-ui Image
@@ -42,6 +43,10 @@ source : Source -> Property msg
 source val =
     property "source" (encodeSource val)
 
+{-| -}
+localSource : Int -> Property msg
+localSource val =
+    property "source" (Encode.int val)
 
 encodeSource : Source -> Encode.Value
 encodeSource source =


### PR DESCRIPTION
Seems that react native when requiring an image
example: `const checked = require('./app/Task/Images/checked@2x.png');`, the returned opaque type returned as an integer.  This allows it to be passed through into the source field of images.  https://facebook.github.io/react-native/docs/image.html#defaultsource.

Still learning elm so this is a quick and dirty pass through.  I can also try and modify the Source type to accept `Int`.