### PR TITLE
Testing and upgrading react-native version

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,13 @@ If you wish, you can also start a file watcher for \*.elm files, which will reco
 $ npm start
 ```
 
+### React native versions
+
+If you use the package.json files from the example projects, you'll get the react native version that has been tested and known to be working with the examples.
+
+That is currently react-native 0.44.3
+
+Later versions of react native may work, however, specifically in the subsequent react native 0.45.x release the "Navigation Experimental" module was depricated and moved to an external library, so the Navigation Example will not work. The intention is to port this to "React Navigation", which is now the accepted approach for react apps. The counter app still works, so if you don't use navigation your app should work with more recent versions.
 
 ## How it works
 

--- a/examples/Counter/app.json
+++ b/examples/Counter/app.json
@@ -1,0 +1,4 @@
+{
+  "name": "Counter",
+  "displayName": "Counter"
+}

--- a/examples/Counter/package.json
+++ b/examples/Counter/package.json
@@ -10,8 +10,8 @@
     "watch": "chokidar '**/*.elm' -c 'npm run compile'"
   },
   "dependencies": {
-    "react": "15.4.0-rc.4",
-    "react-native": "0.41.0"
+    "react": "15.4.1",
+    "react-native": "0.42.3"
   },
   "jest": {
     "preset": "jest-react-native"
@@ -20,7 +20,7 @@
     "babel-jest": "18.0.0",
     "babel-preset-react-native": "1.9.0",
     "chokidar-cli": "^1.2.0",
-    "jest": "18.0.0",
+    "jest": "19.0.2",
     "jest-react-native": "18.0.0",
     "react-test-renderer": "15.4.0-rc.4"
   }

--- a/examples/Counter/package.json
+++ b/examples/Counter/package.json
@@ -11,7 +11,7 @@
   },
   "dependencies": {
     "react": "15.4.0-rc.4",
-    "react-native": "0.40.0"
+    "react-native": "0.41.0"
   },
   "jest": {
     "preset": "jest-react-native"

--- a/examples/Counter/package.json
+++ b/examples/Counter/package.json
@@ -10,18 +10,18 @@
     "watch": "chokidar '**/*.elm' -c 'npm run compile'"
   },
   "dependencies": {
-    "react": "15.3.2",
-    "react-native": "0.39.0"
+    "react": "15.4.0-rc.4",
+    "react-native": "0.40.0"
   },
   "jest": {
     "preset": "jest-react-native"
   },
   "devDependencies": {
-    "babel-jest": "16.0.0",
+    "babel-jest": "18.0.0",
     "babel-preset-react-native": "1.9.0",
     "chokidar-cli": "^1.2.0",
-    "jest": "16.0.2",
-    "jest-react-native": "16.0.0",
-    "react-test-renderer": "15.3.2"
+    "jest": "18.0.0",
+    "jest-react-native": "18.0.0",
+    "react-test-renderer": "15.4.0-rc.4"
   }
 }

--- a/examples/Counter/package.json
+++ b/examples/Counter/package.json
@@ -11,7 +11,7 @@
   },
   "dependencies": {
     "react": "15.3.2",
-    "react-native": "0.38.0"
+    "react-native": "0.39.0"
   },
   "jest": {
     "preset": "jest-react-native"

--- a/examples/Counter/package.json
+++ b/examples/Counter/package.json
@@ -11,7 +11,7 @@
   },
   "dependencies": {
     "react": "15.3.2",
-    "react-native": "0.37.0"
+    "react-native": "0.38.0"
   },
   "jest": {
     "preset": "jest-react-native"

--- a/examples/Counter/package.json
+++ b/examples/Counter/package.json
@@ -10,8 +10,8 @@
     "watch": "chokidar '**/*.elm' -c 'npm run compile'"
   },
   "dependencies": {
-    "react": "15.4.1",
-    "react-native": "0.42.3"
+    "react": "16.0.0-alpha.6",
+    "react-native": "0.43.4"
   },
   "jest": {
     "preset": "jest-react-native"
@@ -22,6 +22,6 @@
     "chokidar-cli": "^1.2.0",
     "jest": "19.0.2",
     "jest-react-native": "18.0.0",
-    "react-test-renderer": "15.4.0-rc.4"
+    "react-test-renderer": "16.0.0-alpha.6"
   }
 }

--- a/examples/Counter/package.json
+++ b/examples/Counter/package.json
@@ -11,7 +11,7 @@
   },
   "dependencies": {
     "react": "15.3.2",
-    "react-native": "0.36.0"
+    "react-native": "0.37.0"
   },
   "jest": {
     "preset": "jest-react-native"

--- a/examples/NavigationDemo/app.json
+++ b/examples/NavigationDemo/app.json
@@ -1,0 +1,4 @@
+{
+  "name": "NavigationDemo",
+  "displayName": "NavigationDemo"
+}

--- a/examples/NavigationDemo/package.json
+++ b/examples/NavigationDemo/package.json
@@ -12,8 +12,8 @@
     "watch": "npm run compile && npm run watch-ios && npm run watch-elm"
   },
   "dependencies": {
-    "react": "15.4.1",
-    "react-native": "0.42.3"
+    "react": "16.0.0-alpha.6",
+    "react-native": "0.43.4"
   },
   "jest": {
     "preset": "jest-react-native"
@@ -24,6 +24,6 @@
     "chokidar-cli": "^1.2.0",
     "jest": "19.0.2",
     "jest-react-native": "18.0.0",
-    "react-test-renderer": "15.4.0-rc.4"
+    "react-test-renderer": "16.0.0-alpha.6"
   }
 }

--- a/examples/NavigationDemo/package.json
+++ b/examples/NavigationDemo/package.json
@@ -13,7 +13,7 @@
   },
   "dependencies": {
     "react": "15.4.0-rc.4",
-    "react-native": "0.40.0"
+    "react-native": "0.41.0"
   },
   "jest": {
     "preset": "jest-react-native"

--- a/examples/NavigationDemo/package.json
+++ b/examples/NavigationDemo/package.json
@@ -13,7 +13,7 @@
   },
   "dependencies": {
     "react": "15.3.2",
-    "react-native": "0.38.0"
+    "react-native": "0.39.0"
   },
   "jest": {
     "preset": "jest-react-native"

--- a/examples/NavigationDemo/package.json
+++ b/examples/NavigationDemo/package.json
@@ -13,7 +13,7 @@
   },
   "dependencies": {
     "react": "15.3.2",
-    "react-native": "0.37.0"
+    "react-native": "0.38.0"
   },
   "jest": {
     "preset": "jest-react-native"

--- a/examples/NavigationDemo/package.json
+++ b/examples/NavigationDemo/package.json
@@ -12,18 +12,18 @@
     "watch": "npm run compile && npm run watch-ios && npm run watch-elm"
   },
   "dependencies": {
-    "react": "15.3.2",
-    "react-native": "0.39.0"
+    "react": "15.4.0-rc.4",
+    "react-native": "0.40.0"
   },
   "jest": {
     "preset": "jest-react-native"
   },
   "devDependencies": {
-    "babel-jest": "17.0.0",
+    "babel-jest": "18.0.0",
     "babel-preset-react-native": "1.9.0",
     "chokidar-cli": "^1.2.0",
-    "jest": "17.0.0",
-    "jest-react-native": "17.0.0",
-    "react-test-renderer": "15.3.2"
+    "jest": "18.0.0",
+    "jest-react-native": "18.0.0",
+    "react-test-renderer": "15.4.0-rc.4"
   }
 }

--- a/examples/NavigationDemo/package.json
+++ b/examples/NavigationDemo/package.json
@@ -12,8 +12,8 @@
     "watch": "npm run compile && npm run watch-ios && npm run watch-elm"
   },
   "dependencies": {
-    "react": "15.4.0-rc.4",
-    "react-native": "0.41.0"
+    "react": "15.4.1",
+    "react-native": "0.42.3"
   },
   "jest": {
     "preset": "jest-react-native"
@@ -22,7 +22,7 @@
     "babel-jest": "18.0.0",
     "babel-preset-react-native": "1.9.0",
     "chokidar-cli": "^1.2.0",
-    "jest": "18.0.0",
+    "jest": "19.0.2",
     "jest-react-native": "18.0.0",
     "react-test-renderer": "15.4.0-rc.4"
   }


### PR DESCRIPTION
I've been going through the react native version on the two examples, and upgrading it version by version. For each minor version, I've tested both examples in both Android and iOS simulators (by manually regression testing).

My goal here is obviously to get them to the current version, to demostrate that react-native-ui still works with current react and is a valid technique (I suspect it is). 

However, at version 0.42.x I've hit a snag with the NavigationDemo example on Android only. The push and pop buttons no longer work. I'm going to see if I can figure out the solution to that, and will them submit further upgrades, but in the meantime this pull request at least brings things up to date as of January 2017. 

Obviously the pull request itself isn't exciting, it's just version number changes, but I've spent about 5 hours of manual testing to verify that it's safe to do so, so it'd be good if other people were saved from that effort by having these version changes.