### PR TITLE
Add Alert and PushNotificationIOS modules

### DIFF
--- a/elm-package.json
+++ b/elm-package.json
@@ -8,6 +8,7 @@
     ],
     "exposed-modules": [
         "NativeUi",
+        "NativeUi.Alert",
         "NativeUi.Image",
         "NativeUi.Style",
         "NativeUi.Elements",

--- a/elm-package.json
+++ b/elm-package.json
@@ -21,7 +21,8 @@
         "NativeApi.Dimensions",
         "NativeApi.NavigationStateUtil",
         "NativeApi.Platform",
-        "NativeApi.StyleSheet"
+        "NativeApi.StyleSheet",
+        "NativeApi.PushNotificationIOS"
     ],
     "native-modules": true,
     "dependencies": {

--- a/src/Native/NativeUi/Alert.js
+++ b/src/Native/NativeUi/Alert.js
@@ -6,7 +6,7 @@ const _ohanhi$elm_native_ui$Native_NativeUi_Alert = function () {
   function alert(title, message, buttons) {
     return _elm_lang$core$Native_Scheduler.nativeBinding(function(callback) {
       const buttonArray = toArray(buttons).map(function(button) {
-        const { _0: text, _1: value } = button;
+        const { text, value } = button;
 
         return {
           text,

--- a/src/Native/NativeUi/Alert.js
+++ b/src/Native/NativeUi/Alert.js
@@ -1,0 +1,26 @@
+const _ohanhi$elm_native_ui$Native_NativeUi_Alert = function () {
+  const { Alert } = require("react-native");
+  const toArray = _elm_lang$core$Native_List.toArray;
+  const unit = { ctor: "_Tuple0" };
+
+  function alert(title, message, buttons) {
+    return _elm_lang$core$Native_Scheduler.nativeBinding(function(callback) {
+      const buttonArray = toArray(buttons).map(function(button) {
+        const { _0: text, _1: value } = button;
+
+        return {
+          text,
+          onPress: () => {
+            callback(_elm_lang$core$Native_Scheduler.succeed(value));
+          },
+        };
+      });
+
+      Alert.alert(title, message, buttonArray);
+    });
+  }
+
+  return {
+    alert: F3(alert),
+  };
+}();

--- a/src/Native/NativeUi/PushNotificationIOS.js
+++ b/src/Native/NativeUi/PushNotificationIOS.js
@@ -1,0 +1,22 @@
+const _ohanhi$elm_native_ui$Native_NativeUi_PushNotificationIOS = function () {
+  const { PushNotificationIOS } = require("react-native");
+
+  function register(_ignored) {
+    return _elm_lang$core$Native_Scheduler.nativeBinding(function(callback) {
+      PushNotificationIOS.addEventListener('register', token => {
+        callback(_elm_lang$core$Native_Scheduler.succeed(token));
+      });
+
+      PushNotificationIOS.addEventListener('registrationError', e => {
+        const errorValue = { ctor: 'Error', _0: e.message };
+        callback(_elm_lang$core$Native_Scheduler.fail(errorValue));
+      });
+
+      PushNotificationIOS.requestPermissions();
+    });
+  }
+
+  return {
+    register,
+  };
+}();

--- a/src/Native/NativeUi/PushNotificationIOS.js
+++ b/src/Native/NativeUi/PushNotificationIOS.js
@@ -1,7 +1,7 @@
 const _ohanhi$elm_native_ui$Native_NativeUi_PushNotificationIOS = function () {
   const { PushNotificationIOS } = require("react-native");
 
-  function register() {
+  function register(_ignored) {
     return _elm_lang$core$Native_Scheduler.nativeBinding(function(callback) {
       PushNotificationIOS.addEventListener('register', token => {
         callback(_elm_lang$core$Native_Scheduler.succeed(token));

--- a/src/Native/NativeUi/PushNotificationIOS.js
+++ b/src/Native/NativeUi/PushNotificationIOS.js
@@ -1,19 +1,17 @@
 const _ohanhi$elm_native_ui$Native_NativeUi_PushNotificationIOS = function () {
   const { PushNotificationIOS } = require("react-native");
 
-  function register(_ignored) {
-    return _elm_lang$core$Native_Scheduler.nativeBinding(function(callback) {
-      PushNotificationIOS.addEventListener('register', token => {
-        callback(_elm_lang$core$Native_Scheduler.succeed(token));
-      });
-
-      PushNotificationIOS.addEventListener('registrationError', e => {
-        callback(_elm_lang$core$Native_Scheduler.fail(e.message));
-      });
-
-      PushNotificationIOS.requestPermissions();
+  const register = _elm_lang$core$Native_Scheduler.nativeBinding(function(callback) {
+    PushNotificationIOS.addEventListener('register', token => {
+      callback(_elm_lang$core$Native_Scheduler.succeed(token));
     });
-  }
+
+    PushNotificationIOS.addEventListener('registrationError', e => {
+      callback(_elm_lang$core$Native_Scheduler.fail(e.message));
+    });
+
+    PushNotificationIOS.requestPermissions();
+  });
 
   return {
     register,

--- a/src/Native/NativeUi/PushNotificationIOS.js
+++ b/src/Native/NativeUi/PushNotificationIOS.js
@@ -1,15 +1,14 @@
 const _ohanhi$elm_native_ui$Native_NativeUi_PushNotificationIOS = function () {
   const { PushNotificationIOS } = require("react-native");
 
-  function register(_ignored) {
+  function register() {
     return _elm_lang$core$Native_Scheduler.nativeBinding(function(callback) {
       PushNotificationIOS.addEventListener('register', token => {
         callback(_elm_lang$core$Native_Scheduler.succeed(token));
       });
 
       PushNotificationIOS.addEventListener('registrationError', e => {
-        const errorValue = { ctor: 'Error', _0: e.message };
-        callback(_elm_lang$core$Native_Scheduler.fail(errorValue));
+        callback(_elm_lang$core$Native_Scheduler.fail(e.message));
       });
 
       PushNotificationIOS.requestPermissions();

--- a/src/NativeApi/PushNotificationIOS.elm
+++ b/src/NativeApi/PushNotificationIOS.elm
@@ -1,7 +1,7 @@
-module NativeApi.PushNotificationIOS exposing (Error(..), register)
+module NativeApi.PushNotificationIOS exposing (register)
 
 {-|
-@docs Error, register
+@docs register
 -}
 
 import Native.NativeUi.PushNotificationIOS
@@ -9,11 +9,6 @@ import Task exposing (Task)
 
 
 {-| -}
-type Error
-    = Error String
-
-
-{-| -}
-register : Task Error String
+register : Task String String
 register =
-    Native.NativeUi.PushNotificationIOS.register "ignored"
+    Native.NativeUi.PushNotificationIOS.register

--- a/src/NativeApi/PushNotificationIOS.elm
+++ b/src/NativeApi/PushNotificationIOS.elm
@@ -4,11 +4,15 @@ module NativeApi.PushNotificationIOS exposing (register)
 @docs register
 -}
 
-import Native.NativeUi.PushNotificationIOS
 import Task exposing (Task)
+import Native.NativeUi.PushNotificationIOS
 
 
-{-| -}
+{-| Returns a Task that resolves with the push token for this app installation
+if the user accepts the system permissions dialog. If they don't accept the
+dialog, the task doesn't resolve. If there is an error (like running on a
+simulator), the Task will fail with an error message String.
+-}
 register : Task String String
 register =
     Native.NativeUi.PushNotificationIOS.register

--- a/src/NativeApi/PushNotificationIOS.elm
+++ b/src/NativeApi/PushNotificationIOS.elm
@@ -1,0 +1,20 @@
+module NativeApi.PushNotificationIOS exposing (Error(..), register)
+
+{-|
+@docs Error, register
+-}
+
+import Native.NativeUi.PushNotificationIOS
+import Task exposing (Task)
+
+
+{-| -}
+type Error
+    = Error String
+
+
+{-| -}
+register : Task Error String
+register =
+    Debug.log "hi there!" <|
+        Native.NativeUi.PushNotificationIOS.register "ignored"

--- a/src/NativeApi/PushNotificationIOS.elm
+++ b/src/NativeApi/PushNotificationIOS.elm
@@ -16,5 +16,4 @@ type Error
 {-| -}
 register : Task Error String
 register =
-    Debug.log "hi there!" <|
-        Native.NativeUi.PushNotificationIOS.register "ignored"
+    Native.NativeUi.PushNotificationIOS.register "ignored"

--- a/src/NativeApi/PushNotificationIOS.elm
+++ b/src/NativeApi/PushNotificationIOS.elm
@@ -11,4 +11,4 @@ import Task exposing (Task)
 {-| -}
 register : Task String String
 register =
-    Native.NativeUi.PushNotificationIOS.register
+    Native.NativeUi.PushNotificationIOS.register "ignored"

--- a/src/NativeApi/PushNotificationIOS.elm
+++ b/src/NativeApi/PushNotificationIOS.elm
@@ -11,4 +11,4 @@ import Task exposing (Task)
 {-| -}
 register : Task String String
 register =
-    Native.NativeUi.PushNotificationIOS.register "ignored"
+    Native.NativeUi.PushNotificationIOS.register

--- a/src/NativeUi/Alert.elm
+++ b/src/NativeUi/Alert.elm
@@ -1,16 +1,11 @@
-module NativeUi.Alert exposing (Error, alert)
+module NativeUi.Alert exposing (alert)
 
 {-|
-@docs Error, alert
+@docs alert
 -}
 
 import Native.NativeUi.Alert
 import Task exposing (Task)
-
-
-{-| -}
-type Error
-    = Error String
 
 
 type alias AlertButton =
@@ -20,6 +15,6 @@ type alias AlertButton =
 
 
 {-| -}
-alert : String -> String -> List AlertButton -> Task Error Bool
+alert : String -> String -> List AlertButton -> Task String Bool
 alert =
     Native.NativeUi.Alert.alert

--- a/src/NativeUi/Alert.elm
+++ b/src/NativeUi/Alert.elm
@@ -14,7 +14,9 @@ type Error
 
 
 type alias AlertButton =
-    ( String, Bool )
+    { text : String
+    , value : Bool
+    }
 
 
 {-| -}

--- a/src/NativeUi/Alert.elm
+++ b/src/NativeUi/Alert.elm
@@ -4,8 +4,8 @@ module NativeUi.Alert exposing (alert)
 @docs alert
 -}
 
-import Native.NativeUi.Alert
 import Task exposing (Task)
+import Native.NativeUi.Alert
 
 
 type alias AlertButton =
@@ -14,7 +14,17 @@ type alias AlertButton =
     }
 
 
-{-| -}
+{-| Show a system alert dialog, with the specified title, message, and list of
+  buttons. The returned Task resolves to the Bool value of the button that was
+  pressed.
+
+    NativeUi.alert
+        "Alert title"
+        "Alert message"
+        [ { text = "No thanks", value = False }
+        , { text = "Yes please", value = True }
+        ]
+-}
 alert : String -> String -> List AlertButton -> Task String Bool
-alert =
-    Native.NativeUi.Alert.alert
+alert title message buttons =
+    Native.NativeUi.Alert.alert title message buttons

--- a/src/NativeUi/Alert.elm
+++ b/src/NativeUi/Alert.elm
@@ -1,0 +1,23 @@
+module NativeUi.Alert exposing (Error, alert)
+
+{-|
+@docs Error, alert
+-}
+
+import Native.NativeUi.Alert
+import Task exposing (Task)
+
+
+{-| -}
+type Error
+    = Error String
+
+
+type alias AlertButton =
+    ( String, Bool )
+
+
+{-| -}
+alert : String -> String -> List AlertButton -> Task Error Bool
+alert =
+    Native.NativeUi.Alert.alert

--- a/src/NativeUi/Image.elm
+++ b/src/NativeUi/Image.elm
@@ -8,7 +8,7 @@ module NativeUi.Image
 
 {-| elm-native-ui Image
 
-@docs Source, CacheStrategy, source
+@docs Source, CacheStrategy, defaultSource, source
 -}
 
 import Json.Encode as Encode


### PR DESCRIPTION
This adds an Alert module for showing system dialogs, as well as a PushNotificationIOS module for handling push notifications on.. iOS!

See Purple Train PR for complete real-world usage examples: https://github.com/thoughtbot/PurpleTrainElm/pull/71

Here are some example snippets:

```elm
-- Shows dialog with two buttons
-- App receives `ReceivePushPrePromptResponse` message when user taps a button,
-- with a `Result` containing a boolean that corresponds to the value of the tapped button
Task.attempt ReceivePushPrePromptResponse <|
    NativeUi.alert
        "This is what it sounds like when trains cry"
        "Purple Train can send you notifications when your trains are cancelled!"
        [ { text = "Not Now", value = False }
        , { text = "Give Access", value = True }
        ]
```

```elm
-- Handling result from ReceivePushPrePromptResponse in the update function:
case result of
    Ok True ->
        -- register function kicks off a task that shows the system permission dialog
        -- Calls update with the ReceivePushToken message with a Result of either:
        -- Ok (with the device push token) or Err (with the registration error)
        Task.attempt ReceivePushToken PushNotificationIOS.register

    _ ->
        Cmd.none
```