### PR TITLE
examples/Counter: update react-native cmd in README

### DIFF
--- a/examples/Counter/README.md
+++ b/examples/Counter/README.md
@@ -4,7 +4,7 @@ Assuming you already have react-native and elm setup. From the command
 line run in the examples directory (not this directory!):
 
 ```bash
-$ react-native init Counter 
+$ react-native init Counter --version 0.44.3
 ```
 
 When asked if you want to overwrite index.ios.js and index.android.js


### PR DESCRIPTION
The user must specify that the react-native version is equal to 0.44.3, otherwise the example does not work. Specifically, react-native becomes confused about whether it should be using "index.js" or ("index.android.js" and "index.ios.js").

Thanks!